### PR TITLE
fix(pools,collectibles-farms): make broken APR / earned sort cases actually rank

### DIFF
--- a/src/views/CollectiblesFarms/index.tsx
+++ b/src/views/CollectiblesFarms/index.tsx
@@ -163,8 +163,9 @@ const Pools: React.FC = () => {
             if (!collectiblesFarm.userData || !collectiblesFarm.stakingExtraRewardTokenPrice) {
               return 0
             }
-            return 0
-          //  return collectiblesFarm.userData.pendingReward.times(collectiblesFarm.stakingExtraRewardTokenPrice).toNumber()
+            return collectiblesFarm.userData.pendingReward
+              .times(collectiblesFarm.stakingExtraRewardTokenPrice)
+              .toNumber()
           },
           'desc',
         )

--- a/src/views/Pools/index.tsx
+++ b/src/views/Pools/index.tsx
@@ -143,10 +143,10 @@ const Pools: React.FC = () => {
   const sortPools = (poolsToSort: Pool[]) => {
     switch (sortOption) {
       case 'apr':
-        // Ternary is needed to prevent pools without APR (like MIX) getting top spot
+        // Keep pools without APR (like MIX) at the bottom, then rank by APR value.
         return orderBy(
           poolsToSort,
-          (pool: Pool) => (pool.apr ? 0 : 0),
+          (pool: Pool) => (pool.apr ? pool.apr : 0),
           'desc',
         )
       case 'earned':


### PR DESCRIPTION
## Summary

Two sort cases were stubbed out and silently returned `0` for every row, so selecting those options in the dropdown was a no-op and the visible order just reflected whatever the cards had been hydrated in.

- **Pools (`apr` case):** `(pool.apr ? 0 : 0)` → `(pool.apr ? pool.apr : 0)`. Pools without APR (e.g. MIX) sink to the bottom as the existing comment intended; pools with an APR now rank by their actual value, descending.
- **CollectiblesFarms (`earned` case):** the real implementation `pendingReward * stakingExtraRewardTokenPrice` was sitting commented out under an unconditional `return 0`. Re-enable it. The `userData` / `stakingExtraRewardTokenPrice` guard is preserved unchanged.

Pattern references in the codebase: `Farms.tsx:210` (`farm.apr + farm.lpRewardsApr`) and `VerticalGardens/index.tsx:149` (`verticalGarden.apr ? 1 : 0` shape). Farms-merged style would lose the MIX bottom-of-list behavior the existing comment required, so Pools uses the `(apr ? apr : 0)` form that preserves both intents.

## Changes (2 commits)

- `3d8320a` fix(pools): rank APR sort by value instead of always returning 0
- `68b605e` fix(collectibles-farms): rank earned sort by pendingReward * tokenPrice

## Verification

`git diff` is +5 / −4 across the two affected files. No type or signature changes — `Pool.apr` is already `number` and `userData.pendingReward` is already `BigNumber` per `src/state/types.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)