### PR TITLE
chore(deps): remove unused valtio dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "three": "^0.131.2",
     "typescript": "^4.3.2",
     "universal-cookie": "^4.0.4",
-    "valtio": "^1.1.3",
     "zustand": "^4.5.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16202,11 +16202,6 @@ proxy-addr@~2.0.5:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-proxy-compare@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.0.2.tgz#343e624d0ec399dfbe575f1d365d4fa042c9fc69"
-  integrity sha512-3qUXJBariEj3eO90M3Rgqq3+/P5Efl0t/dl9g/1uVzIQmO3M+ql4hvNH3mYdu8H+1zcKv07YvL55tsY74jmH1A==
-
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -19654,13 +19649,6 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
-
-valtio@^1.1.3:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.2.1.tgz#19d8514ff5c325ce1dc0ad9ef622d1240c6cbce5"
-  integrity sha512-DQayRId14Luiwh/24wJxgswEFeZJHSWpQLjuAgzuRcRS1ZIhq8F/Fh8h7VvJWLm7AGauyPGHhoEeEAlXUb+zsA==
-  dependencies:
-    proxy-compare "2.0.2"
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary

- Remove `valtio` from `package.json` — it was declared but never imported anywhere in `src/`.
- Regenerate `yarn.lock` to drop the corresponding entry.

## Verification

- `grep -rn valtio src/` returns nothing (confirmed before removal).
- `yarn lint` produces the same 9 pre-existing problems as `master`; none mention valtio and removal adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)