### PR TITLE
refactor: unify cookie libraries on js-cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "swiper": "^6.6.1",
     "three": "^0.131.2",
     "typescript": "^4.3.2",
-    "universal-cookie": "^4.0.4",
     "zustand": "^4.5.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React, { lazy, useState } from 'react'
 import { Router, Redirect, Route, Switch } from 'react-router-dom'
 import { ResetCSS } from '@plantswap/uikit'
 import BigNumber from 'bignumber.js'
-import Cookies from 'universal-cookie'
+import Cookies from 'js-cookie'
 import useEagerConnect from 'hooks/useEagerConnect'
 import visitorsApi from 'utils/calls/visitors'
 import { useWeb3React } from '@web3-react/core'
@@ -81,16 +81,15 @@ const App: React.FC = () => {
   const [userId, setUserId] = useState('0x0')
   const [userIdLoaded, setUserIdLoaded] = useState(false)
   const [userIdCreated, setUserIdCreated] = useState(false)
-  const cookies = new Cookies()
   const { account } = useWeb3React()
   const [visitorSearched, setVisitorSearched] = useState(false)
   const [visitorExist, setVisitorExist] = useState(false)
 
   if (userId && userId !== '0x0') {
-    cookies.set('userId', userId, { path: '/' })
+    Cookies.set('userId', userId, { path: '/' })
   }
   else if (!userIdLoaded) {
-    const getUserId = cookies.get('userId')
+    const getUserId = Cookies.get('userId')
     if (getUserId) {
       setUserId(getUserId)
       setUserIdLoaded(true)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4502,11 +4502,6 @@
   dependencies:
     "@types/tern" "*"
 
-"@types/cookie@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
-  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
-
 "@types/decompress@*":
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/@types/decompress/-/decompress-4.2.4.tgz#dd2715d3ac1f566d03e6e302d1a26ffab59f8c5c"
@@ -19529,14 +19524,6 @@ unist-util-visit@^2.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
-
-universal-cookie@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
-  integrity sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==
-  dependencies:
-    "@types/cookie" "^0.3.3"
-    cookie "^0.4.0"
 
 universal-user-agent@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
## Summary

- Replace `universal-cookie` usage in `src/App.tsx` with `js-cookie` (static API: `Cookies.set/get` instead of `new Cookies()`).
- Drop `universal-cookie` from `package.json` and prune it from `yarn.lock`.

## Why js-cookie

- `js-cookie` was already in use for the more complex case in `state/profile/getProfile.ts` (object value with `{ domain, secure, expires }` options). Migrating `App.tsx`'s simple string+path write to it is trivial.
- Smaller bundle; no SSR `req`/`res` features needed (this is a CRA SPA).
- Removing one runtime dependency.

## Verification

- `yarn lint` — clean for the touched files (`src/App.tsx`, `src/state/profile/getProfile.ts`). The other lint errors in the repo are pre-existing and unrelated.
- `tsc --noEmit` — no type errors introduced in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)