### PR TITLE
fix(hooks): dedupe useActiveWeb3React import in useFetchListCallback

### DIFF
--- a/src/hooks/useFetchListCallback.ts
+++ b/src/hooks/useFetchListCallback.ts
@@ -5,7 +5,6 @@ import { useCallback } from 'react'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import resolveListFromUrl from '../utils/getTokenList'
 import resolveENSContentHash from '../utils/ENS/resolveENSContentHash'
-import useWeb3Provider from './useActiveWeb3React'
 
 type FetcherActions = {
   fetchPending: (payload: { requestId: string; url: string }) => void
@@ -14,8 +13,7 @@ type FetcherActions = {
 }
 
 function useFetchListCallback(actions: FetcherActions): (listUrl: string, sendDispatch?: boolean) => Promise<TokenList> {
-  const { library } = useWeb3Provider()
-  const { chainId } = useActiveWeb3React()
+  const { library, chainId } = useActiveWeb3React()
   const { fetchPending, fetchFulfilled, fetchRejected } = actions
 
   const ensResolver = useCallback(


### PR DESCRIPTION
## Summary
- `src/hooks/useFetchListCallback.ts` imported the same module twice under two different default names (`hooks/useActiveWeb3React` as `useActiveWeb3React`, `./useActiveWeb3React` as `useWeb3Provider`) and called the hook twice in the same component.
- `useActiveWeb3React` already returns both `library` and `chainId` (see `src/hooks/useActiveWeb3React.ts:13`), so collapse to one import and one hook call.

## Diff
```diff
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
-import resolveListFromUrl from '../utils/getTokenList'
-import resolveENSContentHash from '../utils/ENS/resolveENSContentHash'
-import useWeb3Provider from './useActiveWeb3React'
+import useActiveWeb3React from 'hooks/useActiveWeb3React'
+import resolveListFromUrl from '../utils/getTokenList'
+import resolveENSContentHash from '../utils/ENS/resolveENSContentHash'
@@
 function useFetchListCallback(actions: FetcherActions): ... {
-  const { library } = useWeb3Provider()
-  const { chainId } = useActiveWeb3React()
+  const { library, chainId } = useActiveWeb3React()
```

## Verification
- `npx eslint src/hooks/useFetchListCallback.ts` → clean.