### PR TITLE
fix(dashboard): move API calls out of render body into useEffect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, useState } from 'react'
+import React, { lazy, useEffect, useRef, useState } from 'react'
 import { Router, Redirect, Route, Switch } from 'react-router-dom'
 import { ResetCSS } from '@plantswap/uikit'
 import BigNumber from 'bignumber.js'
@@ -82,8 +82,8 @@ const App: React.FC = () => {
   const [userIdLoaded, setUserIdLoaded] = useState(false)
   const [userIdCreated, setUserIdCreated] = useState(false)
   const { account } = useWeb3React()
-  const [visitorSearched, setVisitorSearched] = useState(false)
   const [visitorExist, setVisitorExist] = useState(false)
+  const visitorSearchedRef = useRef(false)
 
   if (userId && userId !== '0x0') {
     Cookies.set('userId', userId, { path: '/' })
@@ -107,19 +107,23 @@ const App: React.FC = () => {
     }
   }
   
-  if (account && !visitorSearched) {
-    setVisitorSearched(true)
-    visitorsApi.readVisitorByAddress(account).then((usernames)  => {
+  // Visitor lookup runs after `account` changes. Side effects (network calls)
+  // must not run in the render body — StrictMode would double-fire them and
+  // any re-render before the response resolves would queue an extra request.
+  // The ref guards against re-firing across re-renders without triggering one.
+  useEffect(() => {
+    if (!account || visitorSearchedRef.current) return
+    visitorSearchedRef.current = true
+    visitorsApi.readVisitorByAddress(account).then((usernames) => {
       if (usernames.length > 0) {
         setVisitorExist(true)
-      }
-      else {
+      } else {
         const newVisitor = {
           address: account,
           dateAdded: new Date(),
         }
         if (!visitorExist) {
-          visitorsApi.createVisitors(newVisitor).then(() => 
+          visitorsApi.createVisitors(newVisitor).then(() =>
             setVisitorExist(true)
           ).catch((err) => {
             console.error(err)
@@ -127,7 +131,10 @@ const App: React.FC = () => {
         }
       }
     })
-  }
+    // visitorExist is read from a stale closure intentionally — the original
+    // logic gated duplicate visitor creation within a single fetch cycle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [account])
 
   usePollBlockNumber()
   useEagerConnect()

--- a/src/views/Dashboard/components/users/AddEditAccessForm.tsx
+++ b/src/views/Dashboard/components/users/AddEditAccessForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Text, Button, Input, Grid, Radio } from '@plantswap/uikit'
 import { useTranslation } from 'contexts/Localization'
@@ -46,37 +46,76 @@ const AddEditForm: React.FC<IAddEditForm> = ({ value, handleSubmit, handleChange
     const [usernamesLoaded, setUsernamesLoaded] = useState(false)
     const [pages, setPages] = useState([])
     const [pagesLoaded, setPagesLoaded] = useState(false)
+    const [userTypeCode, setUserTypeCode] = useState('')
+    const [userAccessType, setUserAccessType] = useState('')
+    const [userIdSelected, setUserIdSelected] = useState('')
+    const [pageIdSelected, setPageIdSelected] = useState('')
 
-    if (!userTypeLoaded) {
-        usersApi.readAllUsersType()
-            .then(res => {
-                setUserType(res)
-                setUserTypeLoaded(true)
-            }).catch(err => {
-                console.error(err)
-                setUserTypeLoaded(true)
-            })
-    }
-    if (!usernamesLoaded) {
-        usernamesApi.readAllUsernames()
-            .then(res => {
-                setUsernames(res)
-                setUsernamesLoaded(true)
-            }).catch(err => {
-                console.error(err)
-                setUsernamesLoaded(true)
-            })
-    }
-    if (!pagesLoaded) {
-        pagesApi.readAllPages()
-            .then(res => {
-                setPages(res)
-                setPagesLoaded(true)
-            }).catch(err => {
-                console.error(err)
-                setPagesLoaded(true)
-            })
-    }
+    // Fetch user types once on mount. Side effects (network calls) must not run
+    // in the render body — StrictMode would double-fire them and any re-render
+    // before the response resolves would queue an extra request.
+    useEffect(() => {
+        let cancelled = false
+        if (!userTypeLoaded) {
+            usersApi.readAllUsersType()
+                .then(res => {
+                    if (!cancelled) {
+                        setUserType(res)
+                        setUserTypeLoaded(true)
+                    }
+                }).catch(err => {
+                    if (!cancelled) {
+                        console.error(err)
+                        setUserTypeLoaded(true)
+                    }
+                })
+        }
+        return () => {
+            cancelled = true
+        }
+    }, [userTypeLoaded])
+
+    useEffect(() => {
+        let cancelled = false
+        if (!usernamesLoaded) {
+            usernamesApi.readAllUsernames()
+                .then(res => {
+                    if (!cancelled) {
+                        setUsernames(res)
+                        setUsernamesLoaded(true)
+                    }
+                }).catch(err => {
+                    if (!cancelled) {
+                        console.error(err)
+                        setUsernamesLoaded(true)
+                    }
+                })
+        }
+        return () => {
+            cancelled = true
+        }
+    }, [usernamesLoaded])
+
+    useEffect(() => {
+        let cancelled = false
+        if (!pagesLoaded) {
+            pagesApi.readAllPages()
+                .then(res => {
+                    if (!cancelled) {
+                        setPages(res)
+                        setPagesLoaded(true)
+                    }
+                }).catch(err => {
+                    if (!cancelled) {
+                        console.error(err)
+                        setPagesLoaded(true)
+                    }
+                })
+        }
+        return () => {
+            cancelled = true
+        }
+    }, [pagesLoaded])
 
     const handleSubmitType = () => {
         if (locationAfterSubmit) {
@@ -85,11 +124,6 @@ const AddEditForm: React.FC<IAddEditForm> = ({ value, handleSubmit, handleChange
             onDismiss()
         }
     }
-
-    const [userTypeCode, setUserTypeCode] = useState('')
-    const [userAccessType, setUserAccessType] = useState('')
-    const [userIdSelected, setUserIdSelected] = useState('')
-    const [pageIdSelected, setPageIdSelected] = useState('')
 
     return (
         <form id="formAddUserAccess" onSubmit={handleSubmit}>

--- a/src/views/Dashboard/components/users/AddEditForm.tsx
+++ b/src/views/Dashboard/components/users/AddEditForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Text, Button, Input, Grid, Radio } from '@plantswap/uikit'
 import { useTranslation } from 'contexts/Localization'
@@ -57,18 +57,31 @@ const AddEditForm: React.FC<IAddEditForm> = ({ value, handleSubmit, handleChange
     const { t } = useTranslation()
     const [userType, setUserType] = useState([])
     const [userTypeLoaded, setUserTypeLoaded] = useState(false)
-
-    if (!userTypeLoaded) {
-        usersApi.readAllUsersType()
-            .then((res) => {
-                setUserType(res)
-                setUserTypeLoaded(true)
-            }).catch(err => {
-                console.error(err)
-                setUserTypeLoaded(true)
-            })
-    }
     const [userTypeCode, setUserTypeCode] = useState('')
+
+    // Fetch user types once on mount. Side effects (network calls) must not run
+    // in the render body — StrictMode would double-fire them and any re-render
+    // before the response resolves would queue an extra request.
+    useEffect(() => {
+        let cancelled = false
+        if (!userTypeLoaded) {
+            usersApi.readAllUsersType()
+                .then((res) => {
+                    if (!cancelled) {
+                        setUserType(res)
+                        setUserTypeLoaded(true)
+                    }
+                }).catch(err => {
+                    if (!cancelled) {
+                        console.error(err)
+                        setUserTypeLoaded(true)
+                    }
+                })
+        }
+        return () => {
+            cancelled = true
+        }
+    }, [userTypeLoaded])
 
     const handleSubmitType = () => {
         if (locationAfterSubmit) {

--- a/src/views/Dashboard/index.tsx
+++ b/src/views/Dashboard/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Route } from 'react-router-dom'
 import usersApi from 'utils/calls/users'
 
@@ -22,28 +22,53 @@ const Dashboard = ({ userId }) => {
   const [userTypeAccessLoaded, setUserTypeAccessLoaded] = useState(false)
   const buildRoutes = []
 
-  if(userId === '0x0') {
-    return <NotFound />
-  }
-  if (!userAccessLoaded) {
-    usersApi.readUserAccessByUserId(userId).then((res) => {
-      setUserAccess(res)
-      setUserAccessLoaded(true)
+  // Fetch user access once userId is known. Side effects (network calls) must
+  // not run in the render body — StrictMode would double-fire them and any
+  // re-render before the response resolves would queue an extra request. The
+  // effect must be declared before any early return to satisfy the rules of
+  // hooks.
+  useEffect(() => {
+    let cancelled = false
+    if (!userId || userId === '0x0') {
+      return undefined
+    }
+    if (!userAccessLoaded) {
+      usersApi.readUserAccessByUserId(userId).then((res) => {
+        if (!cancelled) {
+          setUserAccess(res)
+          setUserAccessLoaded(true)
+        }
       }).catch(err => {
-      console.error(err)
-    })
-    if (!userTypeAccessLoaded) {
-      usersApi.readUserByUserId(userId).then(res => {
-        usersApi.readUserAccessByUserTypeCode(res[0].data.userType).then((response) => {
-          setUserTypeAccess(response)
-          setUserTypeAccessLoaded(true)
-        }).catch(err => {
+        if (!cancelled) {
           console.error(err)
-        })
-      }).catch(err => {
-        console.error(err)
+        }
       })
     }
+    if (!userTypeAccessLoaded) {
+      usersApi.readUserByUserId(userId).then(res => {
+        if (cancelled) return null
+        return usersApi.readUserAccessByUserTypeCode(res[0].data.userType)
+      }).then(response => {
+        if (!cancelled && response) {
+          setUserTypeAccess(response)
+          setUserTypeAccessLoaded(true)
+        }
+      }).catch(err => {
+        if (!cancelled) {
+          console.error(err)
+        }
+      })
+    }
+    return () => {
+      cancelled = true
+    }
+    // Only re-run when userId changes; userAccessLoaded/userTypeAccessLoaded
+    // toggles are handled by the early-return guards above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId])
+
+  if(userId === '0x0') {
+    return <NotFound />
   }
 
   const handleAddRoute = (route) => {


### PR DESCRIPTION
## Summary

Four components fire network requests inside their render body, gated only by a `loaded` flag in state:

- `src/views/Dashboard/components/users/AddEditForm.tsx` — `usersApi.readAllUsersType`
- `src/views/Dashboard/components/users/AddEditAccessForm.tsx` — `usersApi.readAllUsersType`, `usernamesApi.readAllUsernames`, `pagesApi.readAllPages`
- `src/App.tsx` — `visitorsApi.readVisitorByAddress` (and the nested `visitorsApi.createVisitors`)
- `src/views/Dashboard/index.tsx` — `usersApi.readUserAccessByUserId` plus the chained `readUserByUserId` → `readUserAccessByUserTypeCode`

## Problem

Calling a promise-returning function during render is a side effect. Two consequences:

1. **React 17 StrictMode double-mounts in dev.** Every effect fires twice; the original render-body code fires twice too, so every API gets hit twice on first load.
2. **Re-renders before the response resolves can queue extra requests.** Because the `!loaded` gate is checked again on the next render, any state update that triggers a re-render mid-flight would start a second request.

## Fix

Each fetch now lives inside `useEffect` with:

- An early-out guard (`if (loaded) return undefined`) wrapped as a single block — keeps the `consistent-return` rule happy.
- A `cancelled` closure flag flipped in the cleanup function so a stale resolution (post-unmount, or after a StrictMode unmount-remount cycle) never calls `setState`.
- The effect declared **before** the early `return <NotFound />` in `Dashboard/index.tsx` so the rules of hooks are satisfied.

In `App.tsx` the `visitorSearched` state was replaced with a `useRef` (matching the pattern in `src/components/GlobalCheckClaimStatus.tsx`) so the “already searched” guard no longer triggers a re-render of its own.

`Dashboard/index.tsx` uses `[userId]` as the only dep: the `userAccessLoaded`/`userTypeAccessLoaded` toggles are handled by the early-out guards, and putting them in deps would cause the cleanup to flip `cancelled = true` while the inner chained fetch was still in flight.

## Test

- `npx eslint` — clean on all four files.
- `npx tsc --noEmit -p .` — no errors in changed files (pre-existing `@types/node` errors in `node_modules` are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)