### PR TITLE
refactor(dashboard): tighten AddEdit*Form prop types

### DIFF
--- a/src/views/Dashboard/components/pages/AddEditForm.tsx
+++ b/src/views/Dashboard/components/pages/AddEditForm.tsx
@@ -4,22 +4,22 @@ import { useTranslation } from 'contexts/Localization'
 import { ContextApi } from 'contexts/Localization/types'
 import { FormErrors } from '../helper'
 
-interface IAddEditForm {
-    value?: any
-    handleSubmit?: any
-    handleChange?: any
-    fieldsState?: any
-    formErrors?: any
-    onDismiss?: any
-    locationAfterSubmit?: any
-}
-
 export interface IPageState {
     pageId?: string
     pageName: string
     pageShortName: string
     pageDescription?: string
   }
+
+interface IAddEditForm {
+    value?: IPageState
+    handleSubmit?: (event: React.SyntheticEvent) => void
+    handleChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+    fieldsState?: { [key: string]: boolean }
+    formErrors?: { [key: string]: string[] }
+    onDismiss?: () => void
+    locationAfterSubmit?: string
+}
 
 export const getFormErrors = (formData: IPageState, t: ContextApi['t']) => {
     const { pageName, pageShortName } = formData

--- a/src/views/Dashboard/components/users/AddEditAccessForm.tsx
+++ b/src/views/Dashboard/components/users/AddEditAccessForm.tsx
@@ -8,16 +8,6 @@ import usernamesApi from 'utils/calls/usernames'
 import pagesApi from 'utils/calls/pages'
 import { FormErrors, SelectStyled, RadioTextStyled } from '../helper'
 
-interface IAddEditForm {
-    value?: any
-    handleSubmit?: any
-    handleChange?: any
-    fieldsState?: any
-    formErrors?: any
-    onDismiss?: any
-    locationAfterSubmit?: any
-}
-
 export interface IUserAccessState {
     userAccessId?: string
     userAccessType: string
@@ -25,6 +15,19 @@ export interface IUserAccessState {
     userTypeCode?: string
     userAccessPageShortName?: string
     userAccessPagesActionId?: string
+    // The form reads `value.userAccessUserTypeId`; callers do not currently populate
+    // it, so it stays optional. Kept here so the form's prop contract stays honest.
+    userAccessUserTypeId?: string
+}
+
+interface IAddEditForm {
+    value?: IUserAccessState
+    handleSubmit?: (event: React.SyntheticEvent) => void
+    handleChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+    fieldsState?: { [key: string]: boolean }
+    formErrors?: { [key: string]: string[] }
+    onDismiss?: () => void
+    locationAfterSubmit?: string
 }
 
 export const getFormErrors = (formData: IUserAccessState, t: ContextApi['t']) => {

--- a/src/views/Dashboard/components/users/AddEditForm.tsx
+++ b/src/views/Dashboard/components/users/AddEditForm.tsx
@@ -6,16 +6,6 @@ import { ContextApi } from 'contexts/Localization/types'
 import usersApi from 'utils/calls/users'
 import { FormErrors, RadioTextStyled } from '../helper'
 
-interface IAddEditForm {
-    value?: any
-    handleSubmit?: any
-    handleChange?: any
-    fieldsState?: any
-    formErrors?: any
-    onDismiss?: any
-    locationAfterSubmit?: any
-}
-
 export interface IUserState {
     userId?: string
     username: string,
@@ -24,6 +14,16 @@ export interface IUserState {
     email: string,
     telephone: string
   }
+
+interface IAddEditForm {
+    value?: IUserState
+    handleSubmit?: (event: React.SyntheticEvent) => void
+    handleChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+    fieldsState?: { [key: string]: boolean }
+    formErrors?: { [key: string]: string[] }
+    onDismiss?: () => void
+    locationAfterSubmit?: string
+}
 
 export const getFormErrors = (formData: IUserState, t: ContextApi['t']) => {
     const { username, email } = formData

--- a/src/views/Dashboard/components/users/AddEditTypeForm.tsx
+++ b/src/views/Dashboard/components/users/AddEditTypeForm.tsx
@@ -4,22 +4,28 @@ import { useTranslation } from 'contexts/Localization'
 import { ContextApi } from 'contexts/Localization/types'
 import { FormErrors } from '../helper'
 
-interface IAddEditForm {
-    value?: any
-    handleSubmit?: any
-    handleChange?: any
-    fieldsState?: any
-    formErrors?: any
-    onDismiss?: any
-    locationAfterSubmit?: any
-}
-
 export interface IUserTypeState {
     userTypeId?: string
     userTypeName: string
     userTypeCode: string
     userTypeInternalDescription?: string
     userTypePublicDescription?: string
+    // The form reads `userTypeShortName` and `userTypeDescription` here and the
+    // formErrors/fieldsState lookups use those names too; callers do not currently
+    // populate them. Declared optional so the prop contract stays honest without
+    // changing runtime behavior.
+    userTypeShortName?: string
+    userTypeDescription?: string
+}
+
+interface IAddEditForm {
+    value?: IUserTypeState
+    handleSubmit?: (event: React.SyntheticEvent) => void
+    handleChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+    fieldsState?: { [key: string]: boolean }
+    formErrors?: { [key: string]: string[] }
+    onDismiss?: () => void
+    locationAfterSubmit?: string
 }
 
 export const getFormErrors = (formData: IUserTypeState, t: ContextApi['t']) => {

--- a/src/views/Dashboard/components/users/AddEditUsernameForm.tsx
+++ b/src/views/Dashboard/components/users/AddEditUsernameForm.tsx
@@ -4,20 +4,20 @@ import { useTranslation } from 'contexts/Localization'
 import { ContextApi } from 'contexts/Localization/types'
 import { FormErrors } from '../helper'
 
-interface IAddEditForm {
-    value?: any
-    handleSubmit?: any
-    handleChange?: any
-    fieldsState?: any
-    formErrors?: any
-    onDismiss?: any
-    locationAfterSubmit?: any
-}
-
 export interface IUserState {
     userId?: string
     username: string
   }
+
+interface IAddEditForm {
+    value?: IUserState
+    handleSubmit?: (event: React.SyntheticEvent) => void
+    handleChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+    fieldsState?: { [key: string]: boolean }
+    formErrors?: { [key: string]: string[] }
+    onDismiss?: () => void
+    locationAfterSubmit?: string
+}
 
 export const getFormErrors = (formData: IUserState, t: ContextApi['t']) => {
     const { username } = formData


### PR DESCRIPTION
Tightens the `any`-typed `IAddEditForm` prop interfaces on the five `AddEdit*Form` components under `src/views/Dashboard/components/` using types that callers already pass.

## Change

Each form's prop interface now uses concrete shapes:

| Prop | Before | After |
| --- | --- | --- |
| `value` | `any` | `IUserState` / `IUserState` / `IUserAccessState` / `IUserTypeState` / `IPageState` (one per file) |
| `handleSubmit` | `any` | `(event: React.SyntheticEvent) => void` |
| `handleChange` | `any` | `(event: React.ChangeEvent<HTMLInputElement>) => void` |
| `fieldsState` | `any` | `{ [key: string]: boolean }` |
| `formErrors` | `any` | `{ [key: string]: string[] }` |
| `onDismiss` | `any` | `() => void` |
| `locationAfterSubmit` | `any` | `string` |

`React.SyntheticEvent` for `handleSubmit` keeps the existing dual call sites (<form onSubmit> + <Button onClick>) compiling without caller-side changes. Every caller in `UsersList`/`UsernamesList`/`UsersAccess`/`UsersType`/`PagesList`/`PagesAccess` and the matching `*Card` files already passes values compatible with these signatures.

## Pre-existing field mismatches surfaced

Tightening surfaced two cases where the form reads fields that the local state interface never declared. Rather than rewrite the form (out of scope) the missing fields are added as `?:` with a comment, preserving the existing runtime behavior:

- `IUserAccessState.userAccessUserTypeId` — read in `AddEditAccessForm.tsx:257`, not populated by any caller.
- `IUserTypeState.userTypeShortName` and `IUserTypeState.userTypeDescription` — read in `AddEditTypeForm.tsx:74,84,91`, not populated by any caller.

If those need to be removed/renamed to match the API, that should be a follow-up PR so this stays a pure type tightening.

## Verification

- `tsc --project tsconfig.json --noEmit`: zero errors in `src/` (the 1.4k-line `node_modules/@types/node/*` output is a pre-existing tsc@4.3.5 vs newer `@types/node` mismatch, not affected by this change).
- `eslint` on all 5 files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)