### PR TITLE
refactor(profile,nft): extract hasSufficientAllowance helper

### DIFF
--- a/src/utils/contractHelpers.ts
+++ b/src/utils/contractHelpers.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers'
+import BigNumber from 'bignumber.js'
 import { simpleRpcProvider } from 'utils/providers'
 import { verticalGardensConfig, collectiblesFarmConfig, poolsConfig } from 'config/constants'
 import { PoolCategory } from 'config/constants/types'
@@ -140,6 +141,26 @@ export const getErc721Contract = (address: string, signer?: ethers.Signer | ethe
 }
 export const getLpContract = (address: string, signer?: ethers.Signer | ethers.providers.Provider) => {
   return getContract(lpTokenAbi, address, signer)
+}
+
+/**
+ * Returns true when `owner`'s allowance on `contract` for `spender` is at least `required`.
+ * Swallows errors and returns false so callers can use it interchangeably in onRequiresApproval
+ * callbacks without per-site try/catch boilerplate.
+ */
+export const hasSufficientAllowance = async (
+  contract: ethers.Contract,
+  owner: string,
+  spender: string,
+  required: BigNumber,
+): Promise<boolean> => {
+  try {
+    const response = await contract.allowance(owner, spender)
+    const currentAllowance = new BigNumber(response.toString())
+    return currentAllowance.gte(required)
+  } catch (error) {
+    return false
+  }
 }
 
 

--- a/src/views/Collectibles/components/ClaimNftModal.tsx
+++ b/src/views/Collectibles/components/ClaimNftModal.tsx
@@ -8,6 +8,7 @@ import { Button, InjectedModalProps, Modal, Text, Flex } from '@plantswap/uikit'
 import { Nft } from 'config/constants/types'
 import useHasPlantBalance from 'hooks/useHasPlantBalance'
 import { usePlant, useMasterGardeningSchoolNftContract } from 'hooks/useContract'
+import { hasSufficientAllowance } from 'utils/contractHelpers'
 import { getMasterGardeningSchoolNftAddress } from 'utils/addressHelpers'
 import { useTranslation } from 'contexts/Localization'
 import useToast from 'hooks/useToast'
@@ -36,7 +37,7 @@ const ClaimNftModal: React.FC<ClaimNftModalProps> = ({ nft, onSuccess, onDismiss
   const plantContract = usePlant()
   const masterGardeningSchoolNftContract = useMasterGardeningSchoolNftContract()
   const masterGardeningSchoolNftContractAddress = getMasterGardeningSchoolNftAddress()
-  const { toastError, toastSuccess } = useToast()
+  const { toastSuccess } = useToast()
 
   const nftCost = new BigNumber(1000000000000000000)
   const nftApproval = new BigNumber(5).times(nftCost)
@@ -48,15 +49,12 @@ const ClaimNftModal: React.FC<ClaimNftModalProps> = ({ nft, onSuccess, onDismiss
   const { isApproving, isApproved, isConfirmed, isConfirming, handleApprove, handleConfirm } =
     useApproveConfirmTransaction({
       onRequiresApproval: async () => {
-        // TODO: Move this to a helper, this check will be probably be used many times
-        try {
-          const response = await plantContract.allowance(account, masterGardeningSchoolNftContractAddress)
-          const currentAllowance = new BigNumber(response.toString())
-          return currentAllowance.gte(nftApproval)
-        } catch (error) {
-          toastError(t('Error'), t('Please try again. Confirm the transaction and make sure you are paying enough gas!'))
-          return false
-        }
+        return hasSufficientAllowance(
+          plantContract,
+          account,
+          masterGardeningSchoolNftContractAddress,
+          nftApproval,
+        )
       },
       onApprove: () => {
         return plantContract.approve(masterGardeningSchoolNftContractAddress, nftApproval.toJSON())
@@ -90,17 +88,6 @@ const ClaimNftModal: React.FC<ClaimNftModalProps> = ({ nft, onSuccess, onDismiss
 
   const handleApprove = () => {
     plantContract.approve(masterGardeningSchoolNftContractAddress, nftApproval.toJSON())
-  } */
-  /*
-  const allowance = async () => {
-    // TODO: Move this to a helper, this check will be probably be used many times
-    try {
-      const response = await plantContract.allowance(account, masterGardeningSchoolNftContractAddress)
-      const currentAllowance = new BigNumber(response.toString())
-      return currentAllowance.gte(nftCost)
-    } catch (error) {
-      return false
-    }
   } */
     
   return (

--- a/src/views/Profile/ProfileCreation/Mint.tsx
+++ b/src/views/Profile/ProfileCreation/Mint.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'contexts/Localization'
 import useApproveConfirmTransaction from 'hooks/useApproveConfirmTransaction'
 import { DEFAULT_TOKEN_DECIMAL } from 'config'
 import { usePlant, useGardeningSchoolNftContract } from 'hooks/useContract'
+import { hasSufficientAllowance } from 'utils/contractHelpers'
 import { Nft } from 'config/constants/types'
 import useHasPlantBalance from 'hooks/useHasPlantBalance'
 import nftList from 'config/constants/nfts'
@@ -30,14 +31,7 @@ const Mint: React.FC = () => {
   const { isApproving, isApproved, isConfirmed, isConfirming, handleApprove, handleConfirm } =
     useApproveConfirmTransaction({
       onRequiresApproval: async () => {
-        // TODO: Move this to a helper, this check will be probably be used many times
-        try {
-          const response = await plantContract.allowance(account, gardeningSchoolContract.address)
-          const currentAllowance = new BigNumber(response.toString())
-          return currentAllowance.gte(minimumPlantRequired)
-        } catch (error) {
-          return false
-        }
+        return hasSufficientAllowance(plantContract, account, gardeningSchoolContract.address, minimumPlantRequired)
       },
       onApprove: () => {
         return plantContract.approve(gardeningSchoolContract.address, allowance.toJSON())

--- a/src/views/Profile/components/ConfirmProfileCreationModal.tsx
+++ b/src/views/Profile/components/ConfirmProfileCreationModal.tsx
@@ -3,6 +3,7 @@ import { Modal, Flex, Text } from '@plantswap/uikit'
 import BigNumber from 'bignumber.js'
 import { useTranslation } from 'contexts/Localization'
 import { usePlant, useProfile } from 'hooks/useContract'
+import { hasSufficientAllowance } from 'utils/contractHelpers'
 import { getPlantswapGardenersAddress } from 'utils/addressHelpers'
 import useApproveConfirmTransaction from 'hooks/useApproveConfirmTransaction'
 import { fetchProfile } from 'state/profile/store'
@@ -38,13 +39,7 @@ const ConfirmProfileCreationModal: React.FC<Props> = ({
   const { isApproving, isApproved, isConfirmed, isConfirming, handleApprove, handleConfirm } =
     useApproveConfirmTransaction({
       onRequiresApproval: async () => {
-        try {
-          const response = await plantContract.allowance(account, profileContract.address)
-          const currentAllowance = new BigNumber(response.toString())
-          return currentAllowance.gte(minimumPlantRequired)
-        } catch (error) {
-          return false
-        }
+        return hasSufficientAllowance(plantContract, account, profileContract.address, minimumPlantRequired)
       },
       onApprove: () => {
         return plantContract.approve(profileContract.address, allowance.toJSON())


### PR DESCRIPTION
## Summary

The PLANT-allowance check (`await contract.allowance(owner, spender); new BigNumber(...).gte(required)`) was copy-pasted in three live sites plus a commented-out duplicate, each with a TODO. Centralize it in a single helper.

## Changes

- **`src/utils/contractHelpers.ts`** — new `hasSufficientAllowance(contract, owner, spender, required): Promise<boolean>` helper that swallows errors and returns `false`.
- **`src/views/Profile/ProfileCreation/Mint.tsx`** — `onRequiresApproval` collapses to a one-liner.
- **`src/views/Profile/components/ConfirmProfileCreationModal.tsx`** — same.
- **`src/views/Collectibles/components/ClaimNftModal.tsx`** — same; also removes the commented-out duplicate `allowance()` block that the TODO pointed at.

## Error-handling consistency

Previously the three call sites diverged: `ClaimNftModal` toasted on error, `Mint` and `ConfirmProfileCreationModal` returned `false` silently. With the helper swallowing errors and returning `false`, all three sites now share the same failure mode (silent false → user can retry). The `useApproveConfirmTransaction` hook already toasts on errors in `handleApprove` / `handleConfirm`, so the user still gets feedback when something goes wrong.

## Verification

- `npx tsc --noEmit` — no errors in `src/` (pre-existing errors in `node_modules/@types/node` are unrelated).
- `npx eslint` on the four touched files — clean.

## Out of scope (follow-up)

`src/views/Profile/components/EditProfileModal/StartView.tsx` has the same `BigNumber(response.toString()).lt(cost)` pattern (inverse comparison, sets state instead of returning a bool). It would slot in cleanly with `!await hasSufficientAllowance(...)`, but the task scoped this PR to the three sites that carried the TODO. Worth a follow-up PR if you want full coverage.