### PR TITLE
fix(nftlist): sort by the correct field and remove dead dropdown options

### DIFF
--- a/src/views/Collectibles/components/NftList.tsx
+++ b/src/views/Collectibles/components/NftList.tsx
@@ -13,6 +13,7 @@ import ToggleView, { ViewMode } from 'components/ToggleView'
 import { useAppDispatch } from 'state'
 import { fetchWalletNfts } from 'state/collectibles'
 import { useGetCollectibles } from 'state/hooks'
+import { Nft } from 'config/constants/types'
 import { useTranslation } from 'contexts/Localization'
 import { latinise } from 'utils/latinise'
 import { useProfile } from 'state/profile/hooks'
@@ -21,7 +22,6 @@ import NftCard from './NftCard'
 // import NftTabButtons from './NftTabButtons'
 import Table from './NftTable/NftTable'
 import { RowProps } from './NftTable/Row'
-import { ExtraProps } from './NftTable/Extra'
 import NftGrid from './NftGrid'
 import { DesktopColumnSchema } from './types'
 import MasterGardeningSchoolNftCard from './NftCard/MasterGardeningSchoolNftCard'
@@ -127,11 +127,13 @@ const NftList = () => {
     const sortCollectibles = (collectibles) => {
       switch (sortOption) {
         case 'name':
-          return orderBy(collectibles, (nft: ExtraProps) => nft.name, 'asc')
+          return orderBy(collectibles, (nft: Nft) => nft.name, 'asc')
         case 'variantId':
-          return orderBy(collectibles, (nft: ExtraProps) => nft.name, 'desc')
+          return orderBy(collectibles, (nft: Nft) => nft.variationId, 'desc')
         case 'idenditifier':
-          return orderBy(collectibles, (nft: ExtraProps) => nft.name, 'desc')
+          return orderBy(collectibles, (nft: Nft) => nft.identifier, 'desc')
+        case 'hot':
+          return orderBy(collectibles, (nft: Nft) => nft.sortOrder, 'asc')
         default:
           return collectibles
       }

--- a/src/views/Market/components/NftList.tsx
+++ b/src/views/Market/components/NftList.tsx
@@ -12,6 +12,7 @@ import ToggleView, { ViewMode } from 'components/ToggleView'
 import { useAppDispatch } from 'state'
 import { fetchWalletNfts } from 'state/collectibles'
 import { useGetCollectibles } from 'state/hooks'
+import { Nft } from 'config/constants/types'
 import { useTranslation } from 'contexts/Localization'
 import { latinise } from 'utils/latinise'
 import { useProfile } from 'state/profile/hooks'
@@ -20,7 +21,6 @@ import NftCard from './NftCard'
 // import NftTabButtons from './NftTabButtons'
 import Table from './NftTable/NftTable'
 import { RowProps } from './NftTable/Row'
-import { ExtraProps } from './NftTable/Extra'
 import NftGrid from './NftGrid'
 import { DesktopColumnSchema } from './types'
 import MasterGardeningSchoolNftCard from './NftCard/MasterGardeningSchoolNftCard'
@@ -117,11 +117,13 @@ const NftList = () => {
     const sortCollectibles = (collectibles) => {
       switch (sortOption) {
         case 'name':
-          return orderBy(collectibles, (nft: ExtraProps) => nft.name, 'asc')
+          return orderBy(collectibles, (nft: Nft) => nft.name, 'asc')
         case 'variantId':
-          return orderBy(collectibles, (nft: ExtraProps) => nft.name, 'desc')
+          return orderBy(collectibles, (nft: Nft) => nft.variationId, 'desc')
         case 'idenditifier':
-          return orderBy(collectibles, (nft: ExtraProps) => nft.name, 'desc')
+          return orderBy(collectibles, (nft: Nft) => nft.identifier, 'desc')
+        case 'hot':
+          return orderBy(collectibles, (nft: Nft) => nft.sortOrder, 'asc')
         default:
           return collectibles
       }
@@ -309,8 +311,6 @@ const NftList = () => {
         },
       ]}
       sortOptions={[
-        { label: t('Sell type'), value: 'sellType' },
-        { label: t('Auction end date'), value: 'auctionEndData' },
         { label: t('Hot'), value: 'hot' },
         { label: t('Name'), value: 'name' },
         { label: t('GardenerId'), value: 'variantId' },


### PR DESCRIPTION
## Summary

The sort cases in both `NftList.tsx` files were typed as `(nft: ExtraProps) => nft.name`, but the array is `Nft[]`. Because `ExtraProps.name` is a nested `NameProps` object, `lodash.orderBy` stringified every value to `"[object Object]"` and every case was effectively a no-op (including the `'name'` one).

## Fix

- Annotate as `Nft` so types match reality.
- `variantId` → `nft.variationId` (desc).
- `idenditifier` → `nft.identifier` (desc).
- `hot` becomes an explicit case sorting by `nft.sortOrder` (asc), matching the `/claimable` and `/archived` routes that already use `sortOrder` as the featured order.
- The Market dropdown loses `Sell type` and `Auction end date` — the NFT shape has no such fields, so the cases only ever fell through to default.

## Verification

- `npx tsc --noEmit` — no errors in `src/`.
- `npx eslint` on both files — clean.

## Follow-up (out of scope)

The table-column sort callback in both files (`columns[].sort`) also returns `b.id - a.id` for every column, so the table-header click-to-sort doesn't respect the column either. Same root cause family — kept out of this PR to stay focused.