### PR TITLE
refactor: extract shared swap-execution logic into useExecuteSwap

### DIFF
--- a/src/hooks/useExecuteSwap.ts
+++ b/src/hooks/useExecuteSwap.ts
@@ -1,0 +1,70 @@
+import React, { useCallback } from 'react'
+import { Percent, Trade } from '@pancakeswap/sdk'
+
+/**
+ * Local swap-execution state used by the Swap and Donate views. Distinct from
+ * `state/swap/store`'s `SwapState`, which is the global swap-store record.
+ */
+export interface SwapExecutionState {
+  tradeToConfirm: Trade | undefined
+  attemptingTxn: boolean
+  swapErrorMessage: string | undefined
+  txHash: string | undefined
+}
+
+export interface UseExecuteSwapParams {
+  swapCallback: (() => Promise<string>) | null
+  tradeToConfirm: Trade | undefined
+  priceImpactWithoutFee: Percent | undefined
+  confirmPriceImpactWithoutFee: (priceImpactWithoutFee: Percent) => Promise<boolean>
+  setSwapState: React.Dispatch<React.SetStateAction<SwapExecutionState>>
+}
+
+/**
+ * Encapsulates the swap-execution flow shared by the Swap and Donate views:
+ *  1. If `priceImpactWithoutFee` is set, prompt the user for confirmation via
+ *     `confirmPriceImpactWithoutFee` (returned by `useConfirmPriceImpactWithoutFee`).
+ *  2. Run `swapCallback` and mirror the result into the view's local
+ *     {@link SwapExecutionState} — `attemptingTxn` toggles around the call,
+ *     `txHash` is captured on success, and the thrown error's `message` is
+ *     surfaced via `swapErrorMessage`.
+ *
+ * `tradeToConfirm` is preserved across the lifecycle so the downstream
+ * `ConfirmSwapModal` renders the same trade during the "Waiting For Confirmation"
+ * view.
+ *
+ * Returns a stable, no-arg callback suitable for `onConfirm` of `ConfirmSwapModal`
+ * and direct invocation from the Swap button in expert mode.
+ */
+export function useExecuteSwap({
+  swapCallback,
+  tradeToConfirm,
+  priceImpactWithoutFee,
+  confirmPriceImpactWithoutFee,
+  setSwapState,
+}: UseExecuteSwapParams): () => Promise<void> {
+  return useCallback(async () => {
+    if (priceImpactWithoutFee) {
+      const ok = await confirmPriceImpactWithoutFee(priceImpactWithoutFee)
+      if (!ok) return
+    }
+    if (!swapCallback) {
+      return
+    }
+
+    setSwapState({ attemptingTxn: true, tradeToConfirm, swapErrorMessage: undefined, txHash: undefined })
+
+    swapCallback()
+      .then((hash) => {
+        setSwapState({ attemptingTxn: false, tradeToConfirm, swapErrorMessage: undefined, txHash: hash })
+      })
+      .catch((error) => {
+        setSwapState({
+          attemptingTxn: false,
+          tradeToConfirm,
+          swapErrorMessage: error.message,
+          txHash: undefined,
+        })
+      })
+  }, [priceImpactWithoutFee, swapCallback, tradeToConfirm, confirmPriceImpactWithoutFee, setSwapState])
+}

--- a/src/views/Foundation/Donate/index.tsx
+++ b/src/views/Foundation/Donate/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import styled from 'styled-components'
-import { CurrencyAmount, JSBI, Trade } from '@pancakeswap/sdk'
+import { CurrencyAmount, JSBI } from '@pancakeswap/sdk'
 import { Button, Text, Box, useModal } from '@plantswap/uikit'
 import { useIsTransactionUnsupported } from 'hooks/Trades'
 import UnsupportedCurrencyFooter from 'components/UnsupportedCurrencyFooter'

--- a/src/views/Foundation/Donate/index.tsx
+++ b/src/views/Foundation/Donate/index.tsx
@@ -7,6 +7,7 @@ import UnsupportedCurrencyFooter from 'components/UnsupportedCurrencyFooter'
 import ProgressSteps from 'components/ProgressSteps'
 import { useTranslation } from 'contexts/Localization'
 import useConfirmPriceImpactWithoutFee from 'hooks/useConfirmPriceImpactWithoutFee'
+import { SwapExecutionState, useExecuteSwap } from 'hooks/useExecuteSwap'
 import { GreyCard } from '../../../components/Card'
 import Column, { AutoColumn } from '../../../components/Layout/Column'
 import ConfirmSwapModal from './components/ConfirmSwapModal'
@@ -85,12 +86,7 @@ export default function FoundationDonate() {
   )
 
   // modal and loading
-  const [{ tradeToConfirm, swapErrorMessage, attemptingTxn, txHash }, setSwapState] = useState<{
-    tradeToConfirm: Trade | undefined
-    attemptingTxn: boolean
-    swapErrorMessage: string | undefined
-    txHash: string | undefined
-  }>({
+  const [{ tradeToConfirm, swapErrorMessage, attemptingTxn, txHash }, setSwapState] = useState<SwapExecutionState>({
     tradeToConfirm: undefined,
     attemptingTxn: false,
     swapErrorMessage: undefined,
@@ -133,28 +129,13 @@ export default function FoundationDonate() {
 
   const [singleHopOnly] = useUserSingleHopOnly()
 
-  const handleSwap = useCallback(async () => {
-    if (priceImpactWithoutFee) {
-      const ok = await confirmPriceImpactWithoutFee(priceImpactWithoutFee)
-      if (!ok) return
-    }
-    if (!swapCallback) {
-      return
-    }
-    setSwapState({ attemptingTxn: true, tradeToConfirm, swapErrorMessage: undefined, txHash: undefined })
-    swapCallback()
-      .then((hash) => {
-        setSwapState({ attemptingTxn: false, tradeToConfirm, swapErrorMessage: undefined, txHash: hash })
-      })
-      .catch((error) => {
-        setSwapState({
-          attemptingTxn: false,
-          tradeToConfirm,
-          swapErrorMessage: error.message,
-          txHash: undefined,
-        })
-      })
-  }, [priceImpactWithoutFee, swapCallback, tradeToConfirm, confirmPriceImpactWithoutFee])
+  const handleSwap = useExecuteSwap({
+    swapCallback,
+    tradeToConfirm,
+    priceImpactWithoutFee,
+    confirmPriceImpactWithoutFee,
+    setSwapState,
+  })
 
   // errors
   const [showInverted, setShowInverted] = useState<boolean>(false)

--- a/src/views/Swap/index.tsx
+++ b/src/views/Swap/index.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'contexts/Localization'
 import SwapWarningTokens from 'config/constants/swapWarningTokens'
 import { getAddress } from 'utils/addressHelpers'
 import useConfirmPriceImpactWithoutFee from 'hooks/useConfirmPriceImpactWithoutFee'
+import { SwapExecutionState, useExecuteSwap } from 'hooks/useExecuteSwap'
 import AddressInputPanel from './components/AddressInputPanel'
 import { GreyCard } from '../../components/Card'
 import Column, { AutoColumn } from '../../components/Layout/Column'
@@ -120,12 +121,7 @@ export default function Swap({ history }: RouteComponentProps) {
   )
 
   // modal and loading
-  const [{ tradeToConfirm, swapErrorMessage, attemptingTxn, txHash }, setSwapState] = useState<{
-    tradeToConfirm: Trade | undefined
-    attemptingTxn: boolean
-    swapErrorMessage: string | undefined
-    txHash: string | undefined
-  }>({
+  const [{ tradeToConfirm, swapErrorMessage, attemptingTxn, txHash }, setSwapState] = useState<SwapExecutionState>({
     tradeToConfirm: undefined,
     attemptingTxn: false,
     swapErrorMessage: undefined,
@@ -168,28 +164,13 @@ export default function Swap({ history }: RouteComponentProps) {
 
   const [singleHopOnly] = useUserSingleHopOnly()
 
-  const handleSwap = useCallback(async () => {
-    if (priceImpactWithoutFee) {
-      const ok = await confirmPriceImpactWithoutFee(priceImpactWithoutFee)
-      if (!ok) return
-    }
-    if (!swapCallback) {
-      return
-    }
-    setSwapState({ attemptingTxn: true, tradeToConfirm, swapErrorMessage: undefined, txHash: undefined })
-    swapCallback()
-      .then((hash) => {
-        setSwapState({ attemptingTxn: false, tradeToConfirm, swapErrorMessage: undefined, txHash: hash })
-      })
-      .catch((error) => {
-        setSwapState({
-          attemptingTxn: false,
-          tradeToConfirm,
-          swapErrorMessage: error.message,
-          txHash: undefined,
-        })
-      })
-  }, [priceImpactWithoutFee, swapCallback, tradeToConfirm, confirmPriceImpactWithoutFee])
+  const handleSwap = useExecuteSwap({
+    swapCallback,
+    tradeToConfirm,
+    priceImpactWithoutFee,
+    confirmPriceImpactWithoutFee,
+    setSwapState,
+  })
 
   // errors
   const [showInverted, setShowInverted] = useState<boolean>(false)

--- a/src/views/Swap/index.tsx
+++ b/src/views/Swap/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
-import { CurrencyAmount, JSBI, Token, Trade } from '@pancakeswap/sdk'
+import { CurrencyAmount, JSBI, Token } from '@pancakeswap/sdk'
 import { Button, Text, ArrowDownIcon, Box, useModal } from '@plantswap/uikit'
 import { useIsTransactionUnsupported } from 'hooks/Trades'
 import UnsupportedCurrencyFooter from 'components/UnsupportedCurrencyFooter'


### PR DESCRIPTION
## What

Promote the price-impact prompt + swap-callback + attempt/success/error state transitions into a single `useExecuteSwap` hook, and call it from both `views/Swap` and `Foundation/Donate`. Export `SwapExecutionState` so both views share the same local `useState` typing.

`handleSwap` in `views/Swap/index.tsx:171-192` and `Foundation/Donate/index.tsx:136-157` are byte-identical — any drift between them is a bug latent in either flow.

## Why

Prevents future drift between two nearly identical flows. Complements the recent `useConfirmPriceImpactWithoutFee` extraction by finally putting the price-impact-prompt-then-execute swap into a hook.

## How

- New: `src/hooks/useExecuteSwap.ts` — encapsulates price-impact confirmation + swap-callback invocation + `attemptingTxn` / `txHash` / `swapErrorMessage` state transitions; deps match the prior `useCallback` array (plus the stable `setSwapState` setter so `react-hooks/exhaustive-deps` is happy).
- `views/Swap/index.tsx`: swap inline `useState<{...}>` typing for `SwapExecutionState`; replace `handleSwap` `useCallback` body with a call to `useExecuteSwap`.
- `Foundation/Donate/index.tsx`: same pattern, same lines (analogous offsets).
- The local variable name `handleSwap` is preserved at both call sites, so `onClick`/`onConfirm` wiring (Swap:437,466 / Donate:300,329) needs no downstream change.

## Verification

- `tsc -p .` → 0 errors project-wide.
- `yarn lint` → my three files clean (8 pre-existing errors elsewhere in `__tests__/state/predictions/...`, `TheBarnBillboard.tsx`, `NftList.tsx`, untouched by this PR).
- Swap-area tests (`src/state/swap/hooks.test.ts`, `reducer.test.ts`) → 7/7 pass. The 369 failing tests in the full suite are pre-existing multicall/predictions/tokens issues that need live RPC and don't touch the refactored code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)