### PR TITLE
fix(useApproveConfirmTransaction): dispatch before await, pass fresh state to callbacks

### DIFF
--- a/src/hooks/useApproveConfirmTransaction.test.tsx
+++ b/src/hooks/useApproveConfirmTransaction.test.tsx
@@ -1,0 +1,191 @@
+import React, { useEffect } from 'react'
+import ReactDOM from 'react-dom'
+import { act } from 'react-dom/test-utils'
+
+// Captured by the jest.mock factories below so individual tests can inspect
+// what the hook did without resorting to require().
+const mockToastError = jest.fn()
+
+// Mock the hook's collaborators so we can exercise it in isolation without
+// standing up a real web3 provider, toast portal, or i18n context.
+jest.mock('hooks/useActiveWeb3React', () => ({
+  __esModule: true,
+  default: () => ({ account: '0xabc' }),
+}))
+jest.mock('hooks/useToast', () => ({
+  __esModule: true,
+  default: () => ({ toastError: mockToastError, toastSuccess: jest.fn() }),
+}))
+jest.mock('contexts/Localization', () => ({
+  __esModule: true,
+  useTranslation: () => ({ t: (s: string) => s }),
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const useApproveConfirmTransaction = require('./useApproveConfirmTransaction').default
+
+// Minimal TransactionResponse shape the hook actually touches: a `wait()` method
+// returning the receipt we want it to see.
+const makeTx = (status: number) => ({
+  wait: () => Promise.resolve({ status }),
+})
+
+type HookResult = ReturnType<typeof useApproveConfirmTransaction>
+type HookProps = Parameters<typeof useApproveConfirmTransaction>[0]
+
+// Renders the hook inside a real component, exposes its return value via a
+// closure-scoped ref so the test can read it after each render.
+let latest: HookResult | null = null
+const Harness: React.FC<{ props: HookProps }> = ({ props }) => {
+  const result = useApproveConfirmTransaction(props)
+  useEffect(() => {
+    latest = result
+  })
+  return null
+}
+
+// Asserts the ref has been populated by a prior render and narrows its type.
+const getLatest = (): HookResult => {
+  if (latest === null) {
+    throw new Error('hook has not rendered yet')
+  }
+  return latest
+}
+
+const render = (props: HookProps) => {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    ReactDOM.render(<Harness props={props} />, container)
+  })
+  return {
+    unmount: () => {
+      act(() => {
+        ReactDOM.unmountComponentAtNode(container)
+      })
+      container.remove()
+    },
+  }
+}
+
+describe('useApproveConfirmTransaction', () => {
+  beforeEach(() => {
+    mockToastError.mockClear()
+  })
+
+  afterEach(() => {
+    latest = null
+  })
+
+  it('exposes loading flags derived from the reducer state', () => {
+    render({
+      onApprove: () => makeTx(1) as never,
+      onConfirm: () => makeTx(1) as never,
+      onSuccess: () => undefined,
+    })
+    const result = getLatest()
+    expect(result.isApproving).toBe(false)
+    expect(result.isApproved).toBe(false)
+    expect(result.isConfirming).toBe(false)
+    expect(result.isConfirmed).toBe(false)
+  })
+
+  it('flips isApproving to true synchronously on click, before the tx resolves', async () => {
+    // tx.wait() blocks until we resolve it manually — gives us a chance to
+    // observe the mid-flight state.
+    let resolveWait!: (receipt: { status: number }) => void
+    const tx = {
+      wait: () =>
+        new Promise<{ status: number }>((resolve) => {
+          resolveWait = resolve
+        }),
+    }
+
+    render({
+      onApprove: () => tx as never,
+      onConfirm: () => makeTx(1) as never,
+      onSuccess: () => undefined,
+    })
+
+    await act(async () => {
+      // Don't await: handleApprove awaits onApprove() (which returns synchronously),
+      // then awaits tx.wait(). Kick it off and let microtasks flush.
+      getLatest().handleApprove()
+      // Yield to the microtask queue so the inner `await onApprove()` resolves
+      // and the dispatch('approve_sending') happens.
+      await Promise.resolve()
+    })
+
+    const mid = getLatest()
+    expect(mid.isApproving).toBe(true)
+    expect(mid.isApproved).toBe(false)
+
+    // Now resolve the receipt and let the rest of handleApprove finish.
+    await act(async () => {
+      resolveWait({ status: 1 })
+      // Let the awaited receipt + onApproveSuccess settle.
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const end = getLatest()
+    expect(end.isApproving).toBe(false)
+    expect(end.isApproved).toBe(true)
+  })
+
+  it('passes state with approvalState=success to onApproveSuccess (not the stale pre-dispatch state)', async () => {
+    const onApproveSuccess = jest.fn()
+
+    render({
+      onApprove: () => makeTx(1) as never,
+      onConfirm: () => makeTx(1) as never,
+      onSuccess: () => undefined,
+      onApproveSuccess,
+    })
+
+    await act(async () => {
+      await getLatest().handleApprove()
+    })
+
+    expect(onApproveSuccess).toHaveBeenCalledTimes(1)
+    const passed = onApproveSuccess.mock.calls[0][0]
+    // The whole point of the fix: callers must see approvalState === 'success',
+    // not the 'loading' value that was in `state` at the time the closure was built.
+    expect(passed).toEqual({ approvalState: 'success', confirmState: 'idle' })
+  })
+
+  it('passes state with confirmState=success to onSuccess', async () => {
+    const onSuccess = jest.fn()
+
+    render({
+      onApprove: () => makeTx(1) as never,
+      onConfirm: () => makeTx(1) as never,
+      onSuccess,
+    })
+
+    await act(async () => {
+      await getLatest().handleConfirm()
+    })
+
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    const passed = onSuccess.mock.calls[0][0]
+    expect(passed).toEqual({ approvalState: 'idle', confirmState: 'success' })
+  })
+
+  it('flips isApproved to false and surfaces the error toast when approve reverts', async () => {
+    render({
+      onApprove: () => ({ wait: () => Promise.reject(new Error('user rejected')) }) as never,
+      onConfirm: () => makeTx(1) as never,
+      onSuccess: () => undefined,
+    })
+
+    await act(async () => {
+      await getLatest().handleApprove()
+    })
+
+    const result = getLatest()
+    expect(result.isApproved).toBe(false)
+    expect(result.isApproving).toBe(false)
+    expect(mockToastError).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/useApproveConfirmTransaction.ts
+++ b/src/hooks/useApproveConfirmTransaction.ts
@@ -106,13 +106,17 @@ const useApproveConfirmTransaction = ({
     isConfirming: state.confirmState === 'loading',
     isConfirmed: state.confirmState === 'success',
     handleApprove: async () => {
+      // Dispatch before awaiting so the UI reflects the loading state immediately,
+      // not after the wallet popup has resolved.
+      dispatch({ type: 'approve_sending' })
       try {
         const tx = await onApprove()
-        dispatch({ type: 'approve_sending' })
         const receipt = await tx.wait()
         if (receipt.status) {
           dispatch({ type: 'approve_receipt' })
-          onApproveSuccess(state)
+          // Build the post-dispatch state explicitly: `state` from this closure is
+          // still the pre-receipt value because useReducer updates asynchronously.
+          onApproveSuccess({ ...state, approvalState: 'success' })
         }
       } catch (error) {
         dispatch({ type: 'approve_error' })
@@ -126,7 +130,8 @@ const useApproveConfirmTransaction = ({
         const receipt = await tx.wait()
         if (receipt.status) {
           dispatch({ type: 'confirm_receipt' })
-          onSuccess(state)
+          // Same rationale as handleApprove: avoid the stale-closure state.
+          onSuccess({ ...state, confirmState: 'success' })
         }
       } catch (error) {
         dispatch({ type: 'confirm_error' })


### PR DESCRIPTION
## Summary

Hardens \`useApproveConfirmTransaction\` against two ordering bugs that the current call sites (profile creation, profile-pic change, NFT claim, starter-collectible mint) quietly tolerate today but that bite any future caller reading \`state.approvalState\` / \`state.confirmState\` from the callback.

**Bug 1 — late dispatch on approve.** \`handleApprove\` dispatched \`'approve_sending'\` *after* \`await onApprove()\`, so the UI sat in idle while the wallet popup was up, then jumped to loading when the popup resolved. Move the dispatch to the top of the handler.

**Bug 2 — stale state in callbacks.** After dispatching \`'approve_receipt'\` / \`'confirm_receipt'\`, both callbacks were handed the closure's \`state\`, which is still the pre-dispatch value because \`useReducer\` updates asynchronously. Build the post-dispatch state explicitly.

## Changes

- \`src/hooks/useApproveConfirmTransaction.ts\`
  - \`handleApprove\`: \`dispatch({ type: 'approve_sending' })\` now happens *before* \`await onApprove()\`; the callback receives \`{ ...state, approvalState: 'success' }\`.
  - \`handleConfirm\`: callback now receives \`{ ...state, confirmState: 'success' }\`.
- \`src/hooks/useApproveConfirmTransaction.test.tsx\` (new)
  - 5 focused tests using \`react-dom/test-utils\` \`act\` (no new deps):
    1. Initial reducer state surfaces as the four boolean flags.
    2. \`isApproving\` flips to true synchronously on click, before \`tx.wait()\` resolves — covers Bug 1.
    3. \`onApproveSuccess\` receives \`{ approvalState: 'success', confirmState: 'idle' }\` — covers Bug 2.
    4. \`onSuccess\` receives \`{ approvalState: 'idle', confirmState: 'success' }\`.
    5. Reverted tx dispatches error and surfaces toast.

## Verification

- \`yarn test --testPathPattern=useApproveConfirmTransaction\` → 5/5 pass.
- \`yarn lint\` on the touched files → clean (unrelated pre-existing lint errors in \`NftList.tsx\`, \`predictions/helpers.test.ts\`, etc. are unchanged).
- Signature unchanged — all four existing call sites (which currently ignore the \`state\` argument) keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)