### PR TITLE
fix(seo): meta coverage on every route, noindex thin pages, schema cleanup

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,42 @@
   command = "yarn build"
   functions = "functions"
   publish = "build"
+
+# Long cache for CRA-emitted hashed assets — filenames already include content
+# hashes, so `immutable` is safe and lets the browser skip revalidation.
+[[headers]]
+  for = "/static/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# Shorter cache for loose images so content edits propagate within a day.
+[[headers]]
+  for = "/*.svg"
+  [headers.values]
+    Cache-Control = "public, max-age=86400"
+
+[[headers]]
+  for = "/*.jpg"
+  [headers.values]
+    Cache-Control = "public, max-age=86400"
+
+[[headers]]
+  for = "/*.png"
+  [headers.values]
+    Cache-Control = "public, max-age=86400"
+
+# Sitemap regenerates on every build, but cache briefly to keep crawlers happy.
+[[headers]]
+  for = "/sitemap.xml"
+  [headers.values]
+    Cache-Control = "public, max-age=3600"
+
+# Security headers applied to every response.
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains"

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "react-scripts --openssl-legacy-provider start",
-    "build": "react-scripts --openssl-legacy-provider build",
+    "build": "react-scripts --openssl-legacy-provider build && yarn sitemap:generate",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx}\"",
     "format:write": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
+    "sitemap:generate": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/generateSitemap.ts",
     "updateLPsAPR": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/updateLPsAPR.ts"
   },
   "browserslist": {

--- a/public/index.html
+++ b/public/index.html
@@ -49,12 +49,8 @@
         "name": "PlantSwap",
         "alternateName": "PlantSwap.finance",
         "url": "https://plantswap.finance/",
-        "description": "DeFi platform on Binance Smart Chain for farming $PLANT and supporting environmental causes like tree planting and rainforest protection.",
-        "potentialAction": {
-          "@type": "SearchAction",
-          "target": "https://plantswap.finance/?search={search_term_string}",
-          "query-input": "required name=search_term_string"
-        }
+        "inLanguage": "en",
+        "description": "DeFi platform on Binance Smart Chain for farming $PLANT and supporting environmental causes like tree planting and rainforest protection."
       }
     </script>
     <script type="application/ld+json">

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -11,5 +11,7 @@ Disallow: /create
 Disallow: /find
 Disallow: /liquidity
 Disallow: /send
+Disallow: /vote
+Disallow: /documentation
 
 Sitemap: https://plantswap.finance/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,91 +2,103 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://plantswap.finance/</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://plantswap.finance/swap</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://plantswap.finance/farms</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://plantswap.finance/gardens</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://plantswap.finance/pools</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://plantswap.finance/swap</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://plantswap.finance/verticalGardens</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://plantswap.finance/collectiblesFarms</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://plantswap.finance/collectibles</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://plantswap.finance/market</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://plantswap.finance/foundation</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://plantswap.finance/foundation/donate</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://plantswap.finance/project</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plantswap.finance/roadmap</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plantswap.finance/developmentFund</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://plantswap.finance/tree</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://plantswap.finance/documentation</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://plantswap.finance/vote</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
     <loc>https://plantswap.finance/teams</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://plantswap.finance/contact-us</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>

--- a/scripts/generateSitemap.ts
+++ b/scripts/generateSitemap.ts
@@ -1,0 +1,71 @@
+/**
+ * Generates build/sitemap.xml at build time.
+ *
+ * Run automatically after `react-scripts build` via the chained `build` script
+ * in package.json. Also runnable directly via `yarn sitemap:generate`.
+ *
+ * Source of truth for which URLs to include is the INDEXABLE_ROUTES table
+ * below. Update it when adding/removing public routes. Dynamic routes (e.g.
+ * /foundation/proposal/:id) are intentionally NOT listed — the sitemap spec
+ * only covers canonical pages.
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+const SITE_URL = 'https://plantswap.finance'
+const OUTPUT = path.join(__dirname, '..', 'build', 'sitemap.xml')
+
+type ChangeFreq = 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never'
+
+interface Route {
+  loc: string
+  changefreq: ChangeFreq
+  priority: number
+}
+
+const INDEXABLE_ROUTES: Route[] = [
+  { loc: '/', changefreq: 'daily', priority: 1.0 },
+  { loc: '/swap', changefreq: 'daily', priority: 0.9 },
+  { loc: '/farms', changefreq: 'hourly', priority: 0.9 },
+  { loc: '/gardens', changefreq: 'hourly', priority: 0.9 },
+  { loc: '/pools', changefreq: 'hourly', priority: 0.9 },
+  { loc: '/verticalGardens', changefreq: 'daily', priority: 0.8 },
+  { loc: '/collectiblesFarms', changefreq: 'daily', priority: 0.8 },
+  { loc: '/collectibles', changefreq: 'daily', priority: 0.8 },
+  { loc: '/market', changefreq: 'daily', priority: 0.8 },
+  { loc: '/foundation', changefreq: 'daily', priority: 0.8 },
+  { loc: '/foundation/donate', changefreq: 'weekly', priority: 0.7 },
+  { loc: '/project', changefreq: 'monthly', priority: 0.7 },
+  { loc: '/roadmap', changefreq: 'monthly', priority: 0.7 },
+  { loc: '/developmentFund', changefreq: 'weekly', priority: 0.7 },
+  { loc: '/tree', changefreq: 'weekly', priority: 0.7 },
+  { loc: '/teams', changefreq: 'daily', priority: 0.5 },
+  { loc: '/contact-us', changefreq: 'yearly', priority: 0.4 },
+]
+
+const lastmod = new Date().toISOString().slice(0, 10)
+
+const escapeXml = (s: string) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;')
+
+const body = INDEXABLE_ROUTES.map((r) => {
+  const loc = escapeXml(`${SITE_URL}${r.loc}`)
+  return `  <url>
+    <loc>${loc}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>${r.changefreq}</changefreq>
+    <priority>${r.priority.toFixed(1)}</priority>
+  </url>`
+}).join('\n')
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${body}
+</urlset>
+`
+
+fs.mkdirSync(path.dirname(OUTPUT), { recursive: true })
+fs.writeFileSync(OUTPUT, xml, 'utf8')
+// eslint-disable-next-line no-console
+console.log(`[sitemap] wrote ${INDEXABLE_ROUTES.length} URLs to ${OUTPUT} (lastmod=${lastmod})`)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { MASTERGARDENERDEVADDRESS } from 'config'
 import GlobalStyle from './style/Global'
 import Menu from './components/Menu'
 import MenuDev from './components/MenuDev'
+import PageMeta from './components/Layout/PageMeta'
 import SuspenseWithChunkError from './components/SuspenseWithChunkError'
 import { ToastListener } from './contexts/ToastsContext'
 import PageLoader from './components/Loader/PageLoader'
@@ -141,6 +142,7 @@ const App: React.FC = () => {
 
   return (
     <Router history={history}>
+      <PageMeta />
       <ResetCSS />
       <GlobalStyle />
       {account && account === MASTERGARDENERDEVADDRESS ? (

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -1,16 +1,5 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import styled from 'styled-components'
-import { useTranslation } from 'contexts/Localization'
-import { Helmet } from 'react-helmet-async'
-import { useLocation } from 'react-router'
-import {
-  DEFAULT_META,
-  SITE_NAME,
-  getCustomMeta,
-  getNoIndexPaths,
-  getCanonicalUrl,
-} from 'config/constants/meta'
-import { usePricePlantBusd } from 'state/farms/hooks'
 import Container from './Container'
 
 const StyledPage = styled(Container)`
@@ -29,59 +18,8 @@ const StyledPage = styled(Container)`
   }
 `
 
-const PageMeta = () => {
-  const { t } = useTranslation()
-  const { pathname } = useLocation()
-  const plantPriceUsd = usePricePlantBusd()
-  const plantPriceUsdDisplay = plantPriceUsd.gt(0)
-    ? `$${plantPriceUsd.toNumber().toLocaleString(undefined, {
-        minimumFractionDigits: 3,
-        maximumFractionDigits: 3,
-      })}`
-    : ''
-
-  const pageMeta = getCustomMeta(pathname, t) || {}
-  const { title, description, image, noindex } = { ...DEFAULT_META, ...pageMeta }
-  const pageTitle = plantPriceUsdDisplay ? [title, plantPriceUsdDisplay].join(' - ') : title
-
-  const robots = useMemo(() => {
-    if (noindex || getNoIndexPaths(pathname)) return 'noindex, nofollow'
-    return 'index, follow, max-image-preview:large, max-snippet:-1'
-  }, [noindex, pathname])
-
-  const canonical = getCanonicalUrl(pathname)
-  const ogUrl = getCanonicalUrl(pathname)
-
-  return (
-    <Helmet>
-      <title>{pageTitle}</title>
-      {description && <meta name="description" content={description} />}
-      <meta name="robots" content={robots} />
-      <link rel="canonical" href={canonical} />
-
-      <meta property="og:title" content={title} />
-      <meta property="og:site_name" content={SITE_NAME} />
-      <meta property="og:type" content="website" />
-      {description && <meta property="og:description" content={description} />}
-      <meta property="og:url" content={ogUrl} />
-      <meta property="og:image" content={image} />
-
-      <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:title" content={title} />
-      {description && <meta name="twitter:description" content={description} />}
-      <meta name="twitter:image" content={image} />
-      <meta name="twitter:site" content="@plantswap" />
-    </Helmet>
-  )
-}
-
 const Page: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ children, ...props }) => {
-  return (
-    <>
-      <PageMeta />
-      <StyledPage {...props}>{children}</StyledPage>
-    </>
-  )
+  return <StyledPage {...props}>{children}</StyledPage>
 }
 
 export default Page

--- a/src/components/Layout/PageMeta.tsx
+++ b/src/components/Layout/PageMeta.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo } from 'react'
+import { useTranslation } from 'contexts/Localization'
+import { Helmet } from 'react-helmet-async'
+import { useLocation } from 'react-router'
+import {
+  DEFAULT_META,
+  SITE_NAME,
+  getCustomMeta,
+  getNoIndexPaths,
+  getCanonicalUrl,
+  isKnownRoute,
+} from 'config/constants/meta'
+
+const PageMeta = () => {
+  const { t } = useTranslation()
+  const { pathname } = useLocation()
+
+  const pageMeta = getCustomMeta(pathname, t) || {}
+  const { title, description, image, noindex, schema } = { ...DEFAULT_META, ...pageMeta }
+
+  const robots = useMemo(() => {
+    if (noindex || getNoIndexPaths(pathname) || !isKnownRoute(pathname)) return 'noindex, nofollow'
+    return 'index, follow, max-image-preview:large, max-snippet:-1'
+  }, [noindex, pathname])
+
+  const canonical = getCanonicalUrl(pathname)
+
+  return (
+    <Helmet>
+      <title>{title}</title>
+      {description && <meta name="description" content={description} />}
+      <meta name="robots" content={robots} />
+      <link rel="canonical" href={canonical} />
+
+      <meta property="og:title" content={title} />
+      <meta property="og:site_name" content={SITE_NAME} />
+      <meta property="og:type" content="website" />
+      {description && <meta property="og:description" content={description} />}
+      <meta property="og:url" content={canonical} />
+      <meta property="og:image" content={image} />
+      <meta property="og:image:alt" content={title} />
+
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      {description && <meta name="twitter:description" content={description} />}
+      <meta name="twitter:image" content={image} />
+      <meta name="twitter:site" content="@plantswap" />
+
+      {schema && <script type="application/ld+json">{JSON.stringify(schema)}</script>}
+    </Helmet>
+  )
+}
+
+export default PageMeta

--- a/src/config/constants/faq.ts
+++ b/src/config/constants/faq.ts
@@ -1,0 +1,42 @@
+// Single source of truth for the /project FAQ.
+// Used both to render visible Q&A blocks on the page and to emit FAQPage JSON-LD.
+// Update both fields together if a question or answer changes — keeping visible
+// content and structured data in sync avoids Google's "content mismatch" warning.
+
+export type FAQItem = {
+  question: string
+  answer: string
+}
+
+export const PROJECT_FAQ: FAQItem[] = [
+  {
+    question: 'What is PlantSwap?',
+    answer:
+      'PlantSwap is a yield-farming and AMM platform on Binance Smart Chain (BSC) where users earn the $PLANT token through farms and gardens, and where a share of every transaction funds real-world environmental causes like tree planting and rainforest protection.',
+  },
+  {
+    question: 'What problems does PlantSwap solve?',
+    answer:
+      'Too many BSC DeFi platforms to track — farms, pools, and token prices are scattered across dozens of tabs. Hard to know your real yield — fee tier, APR, impermanent gain and loss are usually invisible. Rug pulls from migrator contracts. And DeFi without a mission. PlantSwap addresses each by consolidating farms into one dashboard, making APR transparent, eliminating migrator code entirely, and routing a share of every transaction to environmental non-profits via the Development Fund.',
+  },
+  {
+    question: 'How is PlantSwap different from other BSC yield farms?',
+    answer:
+      'PlantSwap has no migrator contract — your liquidity stays where you put it. It auto-detects your other BSC farms and pools, makes APR and profitability transparent per day/month/year, offers one-click controls to revoke spending approvals and emergency-withdraw from other projects, supports auto-compound and auto-harvest on partner farms, and lets you stake single tokens in PlantSwap gardens for hands-off $PLANT yield.',
+  },
+  {
+    question: 'What is the PlantSwap Development Fund?',
+    answer:
+      'The Development Fund receives 45% to plant trees, 45% burned to lower the total supply, and 10% kept in treasury to cover operating expenses. Every transaction feeds the fund, and donations are published on-chain on the Development Fund page.',
+  },
+  {
+    question: 'How does PlantSwap fund environmental causes?',
+    answer:
+      'A share of every PlantSwap transaction is routed to the Development Fund, which is governed by the community. Holders of $PLANT vote on which non-profits to support through the Foundation. Donations to environmental partners — including rainforest protection and tree-planting organizations — are recorded on-chain and visible on the Development Fund page.',
+  },
+  {
+    question: 'How do I get started with PlantSwap?',
+    answer:
+      'Connect a wallet (such as MetaMask) to Binance Smart Chain, then swap tokens on /swap, provide liquidity and stake LP tokens on /farms, or stake single tokens in auto-compounding gardens on /gardens. The full documentation lives on /documentation, and you can see what is next for the project on the /roadmap.',
+  },
+]

--- a/src/config/constants/meta.ts
+++ b/src/config/constants/meta.ts
@@ -3,7 +3,23 @@ import { PageMeta } from './types'
 
 export const SITE_URL = 'https://plantswap.finance'
 export const SITE_NAME = 'PlantSwap'
-export const DEFAULT_OG_IMAGE = `${SITE_URL}/images/plantswap.jpg`
+
+const og = (filename: string) => `${SITE_URL}/images/${filename}`
+
+export const DEFAULT_OG_IMAGE = og('plantswap.jpg')
+
+export const OG_IMAGES = {
+  farms: og('farms.svg'),
+  garden: og('garden.svg'),
+  verticalGardens: og('verticalGardens.svg'),
+  collectibles: og('collectibles.svg'),
+  foundation: og('developmentFund.svg'),
+  developmentFund: og('developmentFund.svg'),
+  project: og('project.svg'),
+  roadmap: og('roadmap.svg'),
+  tree: og('TREE.svg'),
+  teams: og('teams.svg'),
+}
 
 export const DEFAULT_META: PageMeta = {
   title: 'PlantSwap',
@@ -27,183 +43,416 @@ const withMetaPath = (meta: PageMeta | null, path: string): PageMeta | null => {
   return { ...meta, path }
 }
 
-export const getCustomMeta = (path: string, t: ContextApi['t']): PageMeta => {
-  switch (path) {
-    case '/':
-      return {
-        title: joinTitle(t('Home'), 'PlantSwap'),
-        description:
-          'Farm $PLANT, stake in gardens, swap tokens on BSC, and help plant trees. PlantSwap is the DeFi platform that puts the planet first.',
-        path,
-      }
-    case '/swap':
-      return withMetaPath(
-        buildMeta(path, t('Swap'), 'Swap tokens on PlantSwap — a fast, low-fee AMM on Binance Smart Chain.'),
-        path,
-      )
-    case '/farms':
-      return withMetaPath(
-        buildMeta(
-          path,
-          t('Farms'),
-          'Earn $PLANT and other rewards by providing liquidity to PlantSwap farms on BSC.',
-        ),
-        path,
-      )
-    case '/gardens':
-      return withMetaPath(
-        buildMeta(
-          path,
-          t('Gardens'),
-          'Stake single tokens in PlantSwap gardens to earn $PLANT. Auto-compounding yield farming on BSC.',
-        ),
-        path,
-      )
-    case '/verticalGardens':
-      return withMetaPath(
-        buildMeta(
-          path,
-          t('Vertical Gardens'),
-          'PlantSwap vertical gardens let you earn yield on partner tokens while supporting environmental causes.',
-        ),
-        path,
-      )
-    case '/collectiblesFarms':
-      return withMetaPath(
-        buildMeta(
-          path,
-          t('Collectibles Farms'),
-          'Stake PlantSwap collectible NFTs to earn $PLANT and partner token rewards.',
-        ),
-        path,
-      )
-    case '/pools':
-      return withMetaPath(
-        buildMeta(path, t('Pools'), 'Stake $PLANT in PlantSwap pools to earn more tokens from new projects.'),
-        path,
-      )
-    case '/collectibles':
-      return withMetaPath(
-        buildMeta(path, t('Collectibles'), 'PlantSwap collectibles — NFTs for the community, gamified farming, and more.'),
-        path,
-      )
-    case '/market':
-      return withMetaPath(
-        buildMeta(
-          path,
-          t('Market'),
-          'Trade PlantSwap NFTs on the peer-to-peer marketplace. Buy, sell, auction, and make offers.',
-        ),
-        path,
-      )
-    case '/foundation':
-      return withMetaPath(
-        buildMeta(
-          path,
-          t('Foundation'),
-          'PlantSwap Foundation — community proposals funding rainforest protection, tree planting, and wildlife conservation.',
-        ),
-        path,
-      )
-    case '/vote':
-      return withMetaPath(
-        buildMeta(path, t('Vote'), 'Vote on PlantSwap governance proposals and shape the future of the protocol.'),
-        path,
-      )
-    case '/documentation':
-      return withMetaPath(
-        buildMeta(path, t('Documentation'), 'PlantSwap documentation — guides, contracts, and developer resources.'),
-        path,
-      )
-    case '/project':
-      return withMetaPath(
-        buildMeta(
-          path,
-          t('Project'),
-          'PlantSwap mission — a BSC DeFi platform that funds tree planting, rainforest protection, and wildlife conservation through yield farming.',
-        ),
-        path,
-      )
-    case '/roadmap':
-      return withMetaPath(
-        buildMeta(path, t('Roadmap'), 'The PlantSwap roadmap — past milestones and what is next for $PLANT, farms, and the foundation.'),
-        path,
-      )
-    case '/tree':
-      return withMetaPath(
-        buildMeta(
-          path,
-          t('Tree'),
-          'PlantSwap tree of life — every tree planted by the Development Fund, recorded on-chain.',
-        ),
-        path,
-      )
-    case '/developmentFund':
-      return withMetaPath(
-        buildMeta(
-          path,
-          t('Development Fund'),
-          'The PlantSwap Development Fund — proof of burn and donations to environmental non-profits like the Rainforest Foundation.',
-        ),
-        path,
-      )
-    case '/contact-us':
-      return withMetaPath(
-        buildMeta(path, t('Contact us'), 'Get in touch with the PlantSwap team — partnerships, support, and press.'),
-        path,
-      )
-    case '/teams':
-      return withMetaPath(
-        buildMeta(path, t('Leaderboard'), 'PlantSwap teams leaderboard — climb the rankings and earn rewards.'),
-        path,
-      )
-    case '/profile':
-      return withMetaPath(
-        buildMeta(path, t('Your Profile'), 'Your PlantSwap profile, achievements, and team standings.'),
-        path,
-      )
-    case '/profile/tasks':
-      return withMetaPath(
-        buildMeta(path, t('Task Center'), 'Complete PlantSwap tasks to earn achievements and rewards.'),
-        path,
-      )
-    case '/competition':
-      return withMetaPath(
-        buildMeta(path, t('Trading Battle'), 'PlantSwap trading battle — compete for the top spot.'),
-        path,
-      )
-    case '/prediction':
-      return withMetaPath(
-        buildMeta(path, t('Prediction'), 'PlantSwap prediction markets — bet on token price movements.'),
-        path,
-      )
-    case '/lottery':
-      return withMetaPath(
-        buildMeta(path, t('Lottery'), 'PlantSwap lottery — win $PLANT and other prizes.'),
-        path,
-      )
-    default:
-      return null
+const breadcrumb = (path: string, trail: { name: string; item: string }[]): Record<string, unknown> => ({
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: trail.map((it, idx) => ({
+    '@type': 'ListItem',
+    position: idx + 1,
+    name: it.name,
+    item: it.item,
+  })),
+})
+
+const proposalSchema = (path: string, section: 'Foundation' | 'Voting', parent: string) => ({
+  title: joinTitle(`${section} Proposal`, 'PlantSwap'),
+  description:
+    section === 'Foundation'
+      ? 'PlantSwap Foundation proposal — community-voted environmental funding.'
+      : 'PlantSwap governance proposal — community voting.',
+  image: OG_IMAGES.foundation,
+  path,
+  schema: breadcrumb(path, [
+    { name: 'Home', item: `${SITE_URL}/` },
+    { name: section, item: `${SITE_URL}${parent}` },
+    { name: 'Proposal', item: `${SITE_URL}${path}` },
+  ]),
+})
+
+export const getCustomMeta = (path: string, t: ContextApi['t']): PageMeta | null => {
+  if (path === '/') {
+    return {
+      title: joinTitle(t('Home'), 'PlantSwap'),
+      description:
+        'Farm $PLANT, stake in gardens, swap tokens on BSC, and help plant trees. PlantSwap is the DeFi platform that puts the planet first.',
+      image: DEFAULT_OG_IMAGE,
+      path,
+    }
   }
+
+  // Foundation family
+  if (path === '/foundation') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Foundation'),
+        'PlantSwap Foundation — community proposals funding rainforest protection, tree planting, and wildlife conservation.',
+        OG_IMAGES.foundation,
+      ),
+      path,
+    )
+  }
+  if (path === '/foundation/donate') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Donate'),
+        'Donate to PlantSwap Foundation environmental partners — rainforest protection, tree planting, wildlife conservation.',
+        OG_IMAGES.foundation,
+      ),
+      path,
+    )
+  }
+  if (path === '/foundation/proposal/create') {
+    return withMetaPath(
+      buildMeta(path, t('Create Proposal'), 'Create a PlantSwap Foundation proposal.', OG_IMAGES.foundation, true),
+      path,
+    )
+  }
+  if (/^\/foundation\/proposal\/\d+/.test(path)) {
+    return { ...proposalSchema(path, 'Foundation', '/foundation'), path }
+  }
+  if (/^\/foundation\/nonprofit\/\d+/.test(path)) {
+    return {
+      title: joinTitle(t('Nonprofit'), 'PlantSwap'),
+      description: 'PlantSwap Foundation nonprofit partner — environmental organization funded by the community.',
+      image: OG_IMAGES.foundation,
+      path,
+      schema: breadcrumb(path, [
+        { name: 'Home', item: `${SITE_URL}/` },
+        { name: 'Foundation', item: `${SITE_URL}/foundation` },
+        { name: 'Nonprofit', item: `${SITE_URL}${path}` },
+      ]),
+    }
+  }
+
+  // Voting (dev-only routes; kept noindex in prod)
+  if (path === '/voting') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Voting'),
+        'PlantSwap governance voting — review and vote on community proposals.',
+        OG_IMAGES.foundation,
+        true,
+      ),
+      path,
+    )
+  }
+  if (path === '/voting/proposal/create') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Create Voting Proposal'),
+        'Create a PlantSwap governance proposal.',
+        OG_IMAGES.foundation,
+        true,
+      ),
+      path,
+    )
+  }
+  if (/^\/voting\/proposal\/\d+/.test(path)) {
+    return { ...proposalSchema(path, 'Voting', '/voting'), path }
+  }
+
+  // Teams
+  if (path === '/teams') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Leaderboard'),
+        'PlantSwap teams leaderboard — climb the rankings and earn rewards.',
+        OG_IMAGES.teams,
+      ),
+      path,
+    )
+  }
+  if (/^\/teams\/\d+/.test(path)) {
+    return {
+      title: joinTitle(t('Team'), 'PlantSwap'),
+      description: 'PlantSwap team page — members and standings.',
+      image: OG_IMAGES.teams,
+      path,
+      schema: breadcrumb(path, [
+        { name: 'Home', item: `${SITE_URL}/` },
+        { name: 'Teams', item: `${SITE_URL}/teams` },
+        { name: 'Team', item: `${SITE_URL}${path}` },
+      ]),
+    }
+  }
+
+  // Dashboard
+  if (path === '/dashboard') {
+    return withMetaPath(buildMeta(path, t('Dashboard'), 'Your PlantSwap dashboard.', undefined, true), path)
+  }
+
+  // Liquidity flow — noindexed
+  if (path === '/liquidity' || path === '/find') {
+    return withMetaPath(
+      buildMeta(path, t('Liquidity'), 'PlantSwap liquidity pools on Binance Smart Chain.', undefined, true),
+      path,
+    )
+  }
+  if (path.startsWith('/add') || path.startsWith('/remove') || path.startsWith('/create')) {
+    return withMetaPath(
+      buildMeta(path, t('Add Liquidity'), 'PlantSwap liquidity pools on Binance Smart Chain.', undefined, true),
+      path,
+    )
+  }
+
+  // Swap params — noindexed
+  if (path.startsWith('/swap/')) {
+    return withMetaPath(buildMeta(path, t('Swap Output'), 'Swap a specific token on PlantSwap.', undefined, true), path)
+  }
+
+  // Marketing pages
+  if (path === '/swap') {
+    return withMetaPath(
+      buildMeta(path, t('Swap'), 'Swap tokens on PlantSwap — a fast, low-fee AMM on Binance Smart Chain.'),
+      path,
+    )
+  }
+  if (path === '/farms') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Farms'),
+        'Earn $PLANT and other rewards by providing liquidity to PlantSwap farms on BSC.',
+        OG_IMAGES.farms,
+      ),
+      path,
+    )
+  }
+  if (path === '/gardens') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Gardens'),
+        'Stake single tokens in PlantSwap gardens to earn $PLANT. Auto-compounding yield farming on BSC.',
+        OG_IMAGES.garden,
+      ),
+      path,
+    )
+  }
+  if (path === '/verticalGardens') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Vertical Gardens'),
+        'PlantSwap vertical gardens let you earn yield on partner tokens while supporting environmental causes.',
+        OG_IMAGES.verticalGardens,
+      ),
+      path,
+    )
+  }
+  if (path === '/collectiblesFarms') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Collectibles Farms'),
+        'Stake PlantSwap collectible NFTs to earn $PLANT and partner token rewards.',
+        OG_IMAGES.collectibles,
+      ),
+      path,
+    )
+  }
+  if (path === '/pools') {
+    return withMetaPath(
+      buildMeta(path, t('Pools'), 'Stake $PLANT in PlantSwap pools to earn more tokens from new projects.'),
+      path,
+    )
+  }
+  if (path === '/collectibles') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Collectibles'),
+        'PlantSwap collectibles — NFTs for the community, gamified farming, and more.',
+        OG_IMAGES.collectibles,
+      ),
+      path,
+    )
+  }
+  if (path === '/market') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Market'),
+        'Trade PlantSwap NFTs on the peer-to-peer marketplace. Buy, sell, auction, and make offers.',
+      ),
+      path,
+    )
+  }
+  if (path === '/vote') {
+    return withMetaPath(
+      buildMeta(path, t('Vote'), 'Vote on PlantSwap governance proposals via Snapshot.', undefined, true),
+      path,
+    )
+  }
+  if (path === '/documentation') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Documentation'),
+        'PlantSwap documentation — guides, contracts, and developer resources.',
+        undefined,
+        true,
+      ),
+      path,
+    )
+  }
+  if (path === '/project') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Project'),
+        'PlantSwap mission — a BSC DeFi platform that funds tree planting, rainforest protection, and wildlife conservation through yield farming.',
+        OG_IMAGES.project,
+      ),
+      path,
+    )
+  }
+  if (path === '/roadmap') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Roadmap'),
+        'The PlantSwap roadmap — past milestones and what is next for $PLANT, farms, and the foundation.',
+        OG_IMAGES.roadmap,
+      ),
+      path,
+    )
+  }
+  if (path === '/tree') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Tree'),
+        'PlantSwap tree of life — every tree planted by the Development Fund, recorded on-chain.',
+        OG_IMAGES.tree,
+      ),
+      path,
+    )
+  }
+  if (path === '/developmentFund') {
+    return withMetaPath(
+      buildMeta(
+        path,
+        t('Development Fund'),
+        'The PlantSwap Development Fund — proof of burn and donations to environmental non-profits like the Rainforest Foundation.',
+        OG_IMAGES.developmentFund,
+      ),
+      path,
+    )
+  }
+  if (path === '/contact-us') {
+    return withMetaPath(
+      buildMeta(path, t('Contact us'), 'Get in touch with the PlantSwap team — partnerships, support, and press.'),
+      path,
+    )
+  }
+  if (path === '/profile') {
+    return withMetaPath(
+      buildMeta(path, t('Your Profile'), 'Your PlantSwap profile, achievements, and team standings.', undefined, true),
+      path,
+    )
+  }
+  if (path === '/profile/tasks') {
+    return withMetaPath(
+      buildMeta(path, t('Task Center'), 'Complete PlantSwap tasks to earn achievements and rewards.', undefined, true),
+      path,
+    )
+  }
+  if (path === '/competition') {
+    return withMetaPath(
+      buildMeta(path, t('Trading Battle'), 'PlantSwap trading battle — compete for the top spot.'),
+      path,
+    )
+  }
+  if (path === '/prediction') {
+    return withMetaPath(
+      buildMeta(path, t('Prediction'), 'PlantSwap prediction markets — bet on token price movements.'),
+      path,
+    )
+  }
+  if (path === '/lottery') {
+    return withMetaPath(buildMeta(path, t('Lottery'), 'PlantSwap lottery — win $PLANT and other prizes.'), path)
+  }
+
+  return null
+}
+
+// Source of truth for which paths exist as real routes. PageMeta uses it to
+// noindex unknown URLs; the sitemap generator uses it to know which URLs to list.
+export const KNOWN_ROUTES: Set<string> = new Set([
+  '/',
+  '/swap',
+  '/swap/:outputCurrency',
+  '/farms',
+  '/gardens',
+  '/verticalGardens',
+  '/collectiblesFarms',
+  '/pools',
+  '/collectibles',
+  '/market',
+  '/foundation',
+  '/foundation/donate',
+  '/foundation/proposal/create',
+  '/foundation/proposal/:id',
+  '/foundation/nonprofit/:id',
+  '/voting',
+  '/voting/proposal/create',
+  '/voting/proposal/:id',
+  '/teams',
+  '/teams/:id',
+  '/dashboard',
+  '/liquidity',
+  '/find',
+  '/add',
+  '/add/:currencyIdA',
+  '/add/:currencyIdA/:currencyIdB',
+  '/remove/:tokens',
+  '/remove/:currencyIdA/:currencyIdB',
+  '/create',
+  '/create/:currencyIdA',
+  '/create/:currencyIdA/:currencyIdB',
+  '/vote',
+  '/documentation',
+  '/project',
+  '/roadmap',
+  '/tree',
+  '/developmentFund',
+  '/contact-us',
+  '/profile',
+  '/profile/tasks',
+  '/competition',
+  '/prediction',
+  '/lottery',
+])
+
+export const KNOWN_ROUTE_PATTERNS: RegExp[] = [
+  /^\/foundation\/proposal\/\d+$/,
+  /^\/foundation\/nonprofit\/\d+$/,
+  /^\/voting\/proposal\/\d+$/,
+  /^\/teams\/\d+$/,
+  /^\/add(\/[^/]+){0,2}$/,
+  /^\/remove(\/[^/]+){0,2}$/,
+  /^\/create(\/[^/]+){0,2}$/,
+  /^\/swap\/[^/]+$/,
+]
+
+export const isKnownRoute = (path: string): boolean => {
+  if (KNOWN_ROUTES.has(path)) return true
+  return KNOWN_ROUTE_PATTERNS.some((re) => re.test(path))
 }
 
 export const getNoIndexPaths = (path: string): boolean => {
-  // Admin / private / low-value
-  if (path.startsWith('/dashboard')) return true
-  // Wallet-specific / empty profiles
-  if (path === '/profile') return true
-  // Transaction flows and dynamic liquidity
-  if (path.startsWith('/swap') && path !== '/swap') return true
-  if (path.startsWith('/add') || path.startsWith('/remove')) return true
-  if (path.startsWith('/create') || path === '/find') return true
-  if (path === '/liquidity') return true
-  // NFT listings and per-collection pages
+  if (path === '/dashboard') return true
+  if (path === '/profile' || path === '/profile/tasks') return true
   if (path.startsWith('/market/')) return true
-  // Per-team and per-proposal pages
-  if (/^\/teams\/\d+/.test(path)) return false
-  if (path.startsWith('/voting/proposal/')) return false
-  if (path.startsWith('/foundation/proposal/')) return false
-  if (path.startsWith('/foundation/nonprofit/')) return false
+  if (path.startsWith('/swap/')) return true
+  if (path === '/liquidity' || path === '/find') return true
+  if (path.startsWith('/add') || path.startsWith('/remove') || path.startsWith('/create')) return true
   return false
 }
 

--- a/src/config/constants/roadmap.ts
+++ b/src/config/constants/roadmap.ts
@@ -1,0 +1,4 @@
+// Bump this whenever you edit src/views/Roadmap/Roadmap.tsx.
+// The Article JSON-LD emitted on /roadmap reads ROADMAP_LAST_MODIFIED for
+// `dateModified` — search engines use this to decide whether to recrawl.
+export const ROADMAP_LAST_MODIFIED = '2026-07-07'

--- a/src/config/constants/types.ts
+++ b/src/config/constants/types.ts
@@ -150,7 +150,7 @@ export interface EcologicalNonProfitConfig {
   enpId: number
   description?: string
   isValid?: boolean
-}  
+}
 
 export type Images = {
   lg: string
@@ -240,4 +240,5 @@ export type PageMeta = {
   image?: string
   path?: string
   noindex?: boolean
+  schema?: Record<string, unknown>
 }

--- a/src/views/Collectibles/components/NftTable/Image.tsx
+++ b/src/views/Collectibles/components/NftTable/Image.tsx
@@ -7,19 +7,18 @@ export interface ImageProps {
 }
 
 const NftImage = styled.span`
-  color: ${({ theme }) => (theme.colors.text)};
+  color: ${({ theme }) => theme.colors.text};
   display: flex;
   align-items: center;
   padding-left: 20px;
 `
 
 const Image: React.FunctionComponent<ImageProps> = ({ images, alt }) => {
-
   const rootPath = `/images/nfts/${images}`
-  
+
   return (
     <NftImage>
-      <img src={rootPath} alt={alt} width={100} />
+      <img src={rootPath} alt={alt} width={100} loading="lazy" decoding="async" />
     </NftImage>
   )
 }

--- a/src/views/CollectiblesFarms/index.tsx
+++ b/src/views/CollectiblesFarms/index.tsx
@@ -235,7 +235,14 @@ const Pools: React.FC = () => {
             </Heading>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/collectibles.svg" alt="Gardens" width={600} height={315} />
+            <img
+              src="/images/collectibles.svg"
+              alt="Gardens"
+              width={600}
+              height={315}
+              loading="lazy"
+              decoding="async"
+            />
           </Flex>
         </Flex>
       </PageHeader>

--- a/src/views/ContactUs/ContactUs.tsx
+++ b/src/views/ContactUs/ContactUs.tsx
@@ -9,10 +9,10 @@ import Divider from './components/Divider'
 import { getContactFormErrors, FormErrors } from './helper'
 
 interface ContactFormState {
-  clientName: string;
-  email: string;
-  sujet: string;
-  message: string;
+  clientName: string
+  email: string
+  sujet: string
+  message: string
 }
 
 const ContactUs = () => {
@@ -20,10 +20,10 @@ const ContactUs = () => {
   const [send, setSend] = useState(false)
   const [state, setState] = useState<ContactFormState>({
     clientName: '',
-      email: '',
-      sujet: '',
-      message: '',
-      })
+    email: '',
+    sujet: '',
+    message: '',
+  })
   // eslint-disable-next-line
   const { clientName, email, sujet, message } = state
   // eslint-disable-next-line
@@ -35,28 +35,25 @@ const ContactUs = () => {
     setState((prevState) => ({ ...prevState, [name]: value }))
   }
 
-  const clearState = () => setState({
-    clientName: '',
+  const clearState = () =>
+    setState({
+      clientName: '',
       email: '',
       sujet: '',
       message: '',
-      })
+    })
 
   const handleSubmit = (e: any) => {
     e.preventDefault()
-    emailjs
-      .sendForm(
-        'service_2heraoe', 'template_revj3os', e.target, 'user_LncbCjsg709omIRnMnAH3'
-      )
-      .then(
-        () => {
-          clearState()
-          setSend(true)
-        },
-        (error) => {
-          console.error(error.text)
-        }
-      ) 
+    emailjs.sendForm('service_2heraoe', 'template_revj3os', e.target, 'user_LncbCjsg709omIRnMnAH3').then(
+      () => {
+        clearState()
+        setSend(true)
+      },
+      (error) => {
+        console.error(error.text)
+      },
+    )
   }
 
   return (
@@ -68,24 +65,29 @@ const ContactUs = () => {
               {t('Contact-Us')}
             </Heading>
             <Heading scale="lg" color="text">
-              {t('Learn how to connect your wallet to Plantswap')}<br />
+              {t('Learn how to connect your wallet to Plantswap')}
+              <br />
             </Heading>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/roadmap.svg" alt="Gardens" width={600} height={315} />
+            <img src="/images/roadmap.svg" alt="Gardens" width={600} height={315} loading="lazy" decoding="async" />
           </Flex>
         </Flex>
       </PageHeader>
 
       <Page>
-      {send && (
+        {send && (
           <Flex alignItems="center" mb="16px">
-              <Text color="success" mr="16px">{t('Your message has been sent!')}</Text>
+            <Text color="success" mr="16px">
+              {t('Your message has been sent!')}
+            </Text>
           </Flex>
         )}
         <form id="form" onSubmit={handleSubmit}>
-        <Flex mb="16px">
-            <Text color="textSubtle" mr="16px">{t('Your name')}</Text>
+          <Flex mb="16px">
+            <Text color="textSubtle" mr="16px">
+              {t('Your name')}
+            </Text>
             <Input
               type="hidden"
               name="emailSubject"
@@ -103,75 +105,54 @@ const ContactUs = () => {
               \n\n\n
               Sent from ESportsCentral.ca`}
             />
-        </Flex>
-          <Flex mb="16px">
-              <Input 
-                type="text" 
-                name="clientName" 
-                id="clientName"
-                required
-                onChange={handleChange}
-              />
-              {formErrors.clientName && fieldsState.clientName && <FormErrors errors={formErrors.clientName} />}
           </Flex>
           <Flex mb="16px">
-              <Text color="textSubtle" mr="16px">{t('Your email')}</Text>
+            <Input type="text" name="clientName" id="clientName" required onChange={handleChange} />
+            {formErrors.clientName && fieldsState.clientName && <FormErrors errors={formErrors.clientName} />}
           </Flex>
           <Flex mb="16px">
-              <Input 
-                type="text" 
-                name="email" 
-                id="email"
-                required
-                onChange={handleChange}
-              />
-              {formErrors.email && fieldsState.email && <FormErrors errors={formErrors.email} />}
+            <Text color="textSubtle" mr="16px">
+              {t('Your email')}
+            </Text>
           </Flex>
           <Flex mb="16px">
-              <Text color="textSubtle" mr="16px">{t('Subjet')}</Text>
+            <Input type="text" name="email" id="email" required onChange={handleChange} />
+            {formErrors.email && fieldsState.email && <FormErrors errors={formErrors.email} />}
           </Flex>
           <Flex mb="16px">
-              <Input 
-                type="text" 
-                name="sujet" 
-                id="sujet"
-                required
-                onChange={handleChange} 
-              />
-              {formErrors.sujet && fieldsState.sujet && <FormErrors errors={formErrors.sujet} />}
+            <Text color="textSubtle" mr="16px">
+              {t('Subjet')}
+            </Text>
           </Flex>
-        {clientName && (
-          <>
-            <Flex mb="16px">
-                <Text color="textSubtle" mr="16px">{t('Message')}</Text>
-            </Flex>
-            <Flex mb="16px">
-                <Textarea 
-                  name="message" 
-                  id="message"
-                  value={message}
-                  required
-                  onChange={handleChange} 
-                />
+          <Flex mb="16px">
+            <Input type="text" name="sujet" id="sujet" required onChange={handleChange} />
+            {formErrors.sujet && fieldsState.sujet && <FormErrors errors={formErrors.sujet} />}
+          </Flex>
+          {clientName && (
+            <>
+              <Flex mb="16px">
+                <Text color="textSubtle" mr="16px">
+                  {t('Message')}
+                </Text>
+              </Flex>
+              <Flex mb="16px">
+                <Textarea name="message" id="message" value={message} required onChange={handleChange} />
                 {formErrors.message && fieldsState.message && <FormErrors errors={formErrors.message} />}
-            </Flex>
-            <Flex alignItems="center" mb="16px">
-                <Button 
-                  type="submit" 
-                  id="button" 
-                  value="Send Email"
-                  onClick={() => handleSubmit}
-                  disabled={send}>
+              </Flex>
+              <Flex alignItems="center" mb="16px">
+                <Button type="submit" id="button" value="Send Email" onClick={() => handleSubmit} disabled={send}>
                   {t('Send your message')}
                 </Button>
-            </Flex>
+              </Flex>
             </>
-        )}
-            {send && (
-                <Flex alignItems="center" mb="16px">
-                    <Text color="success" mr="16px">{t('Your message has been sent!')}</Text>
-                </Flex>
-            )}
+          )}
+          {send && (
+            <Flex alignItems="center" mb="16px">
+              <Text color="success" mr="16px">
+                {t('Your message has been sent!')}
+              </Text>
+            </Flex>
+          )}
         </form>
         <Divider />
         <EndPage />
@@ -209,4 +190,4 @@ const Textarea = styled.textarea`
   &:focus:not(:disabled) {
     box-shadow: ${({ theme }) => theme.shadows.focus};
   }
-`;
+`

--- a/src/views/DevelopmentFund/DevelopmentFund.tsx
+++ b/src/views/DevelopmentFund/DevelopmentFund.tsx
@@ -19,51 +19,99 @@ const DevelopmentFund = () => {
               {t('Development Fund')}
             </Heading>
             <Heading scale="lg" color="text">
-              {t('Find the details on the PlantSwap Development Fund')}<br />
+              {t('Find the details on the PlantSwap Development Fund')}
+              <br />
               {t('The contribution to non-profits and proof of burn')}
             </Heading>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/developmentFund.svg" alt="PlantSwap Development Fund — proof of burn and donations to environmental non-profits" width={600} height={315} />
+            <img
+              src="/images/developmentFund.svg"
+              alt="PlantSwap Development Fund — proof of burn and donations to environmental non-profits"
+              width={600}
+              height={315}
+              loading="lazy"
+              decoding="async"
+            />
           </Flex>
         </Flex>
       </PageHeader>
       <MasterGardener />
       <Page>
-        <Heading as="h2" size="xl" mb="14px">What is the PlantSwap Development Fund?</Heading>
+        <Heading as="h2" size="xl" mb="14px">
+          What is the PlantSwap Development Fund?
+        </Heading>
         <br />
-        <Text>The PlantSwap Development Fund is the on-chain treasury that turns a share of every yield-farming fee on the <a href="/farms">PlantSwap farms</a> and <a href="/gardens">gardens</a> into real-world environmental impact.</Text>
-        <Text>Every time users harvest $PLANT from a farm or garden, a portion of the rewards is redirected to the Development Fund. The community then votes — through the <a href="/foundation">PlantSwap Foundation</a> — on which environmental non-profits the fund should support.</Text>
+        <Text>
+          The PlantSwap Development Fund is the on-chain treasury that turns a share of every yield-farming fee on the{' '}
+          <a href="/farms">PlantSwap farms</a> and <a href="/gardens">gardens</a> into real-world environmental impact.
+        </Text>
+        <Text>
+          Every time users harvest $PLANT from a farm or garden, a portion of the rewards is redirected to the
+          Development Fund. The community then votes — through the <a href="/foundation">PlantSwap Foundation</a> — on
+          which environmental non-profits the fund should support.
+        </Text>
         <br />
-        <Heading as="h2" size="xl" mb="14px">How fees are split</Heading>
+        <Heading as="h2" size="xl" mb="14px">
+          How fees are split
+        </Heading>
         <br />
         <Text>45% 🌲 will go to plant trees 🌲</Text>
         <Text>45% 🔥 will be burned to lower the total supply 🔥</Text>
         <Text>10% 💸 kept in treasury to cover operating expense 💸</Text>
         <br />
-        <Heading as="h2" size="xl" mb="14px">Current non-profits supported by the Development Fund</Heading>
+        <Heading as="h2" size="xl" mb="14px">
+          Current non-profits supported by the Development Fund
+        </Heading>
         <br />
-        <Heading as="h3" size="lg" mb="16px">The Rainforest Foundation</Heading>
-        <Text>The Rainforest Foundation is a charitable foundation founded in 1987 and dedicated to drawing attention to rainforests and defending the rights of indigenous peoples living there.</Text>
+        <Heading as="h3" size="lg" mb="16px">
+          The Rainforest Foundation
+        </Heading>
+        <Text>
+          The Rainforest Foundation is a charitable foundation founded in 1987 and dedicated to drawing attention to
+          rainforests and defending the rights of indigenous peoples living there.
+        </Text>
         <br />
-        <Heading as="h2" size="xl" mb="14px">Frequency and proof on-chain</Heading>
+        <Heading as="h2" size="xl" mb="14px">
+          Frequency and proof on-chain
+        </Heading>
         <br />
-        <Text>Donations are sent on a recurring basis as the fund grows and more non-profits are added to the roster. Every donation transaction is published below and on-chain so anyone can independently verify the impact.</Text>
+        <Text>
+          Donations are sent on a recurring basis as the fund grows and more non-profits are added to the roster. Every
+          donation transaction is published below and on-chain so anyone can independently verify the impact.
+        </Text>
         <br />
-        <Heading as="h2" size="xl" mb="14px">Last donations</Heading>
+        <Heading as="h2" size="xl" mb="14px">
+          Last donations
+        </Heading>
         <Donation>
           <br />
           <ul>
-            <li>250$ - Rainforest Foundation (https://etherscan.io/tx/0xdcda28b246ba81a9068a9db599f41bccc90f17b65799eb8c5835b3a8cc631ee0)</li>
-            <li>4200$ - Rainforest Foundation (https://etherscan.io/tx/0xdbeac34c17995294466e4248e31db05f646e79980c1ebfad8034a198cd151c79)</li>
-            <li>6000$ - Rainforest Foundation (https://etherscan.io/tx/0xd40c9d84e75c3169aeb5cb6831782ed4438216932e172720a54804fbf0f73f9b)</li>
-            <li>50$ - Rainforest Foundation (https://etherscan.io/tx/0x967c5ad8c523406f0515dc7a98faaf942946008531c3a066ca9aec6146b3d56f)</li>
+            <li>
+              250$ - Rainforest Foundation
+              (https://etherscan.io/tx/0xdcda28b246ba81a9068a9db599f41bccc90f17b65799eb8c5835b3a8cc631ee0)
+            </li>
+            <li>
+              4200$ - Rainforest Foundation
+              (https://etherscan.io/tx/0xdbeac34c17995294466e4248e31db05f646e79980c1ebfad8034a198cd151c79)
+            </li>
+            <li>
+              6000$ - Rainforest Foundation
+              (https://etherscan.io/tx/0xd40c9d84e75c3169aeb5cb6831782ed4438216932e172720a54804fbf0f73f9b)
+            </li>
+            <li>
+              50$ - Rainforest Foundation
+              (https://etherscan.io/tx/0x967c5ad8c523406f0515dc7a98faaf942946008531c3a066ca9aec6146b3d56f)
+            </li>
           </ul>
           <br />
           <Text>Thank you for your support!</Text>
         </Donation>
         <Divider />
-        <Text>Want to suggest a non-profit or vote on the next donation? Open a proposal in the <a href="/foundation">PlantSwap Foundation</a>.</Text>
+        <Text>
+          Want to suggest a non-profit or vote on the next donation? Open a proposal in the{' '}
+          <a href="/foundation">PlantSwap Foundation</a>.
+        </Text>
         <EndPage />
       </Page>
     </>

--- a/src/views/Documentation/Documentation.tsx
+++ b/src/views/Documentation/Documentation.tsx
@@ -18,32 +18,35 @@ const Documentation = () => {
               {t('Documentation')}
             </Heading>
             <Heading scale="lg" color="text">
-              {t('Learn how to connect your wallet to Plantswap')}<br />
+              {t('Learn how to connect your wallet to Plantswap')}
+              <br />
             </Heading>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/roadmap.svg" alt="Gardens" width={600} height={315} />
+            <img src="/images/roadmap.svg" alt="Gardens" width={600} height={315} loading="lazy" decoding="async" />
           </Flex>
         </Flex>
       </PageHeader>
 
       <Page>
-        <Heading as="h2" size="xl" mb="14px">Connecting MetaMask to Binance Smart Chain</Heading>
-        
-        <ReactPlayer 
-          url="https://www.youtube.com/watch?v=HVH6wpaHcDI" 
+        <Heading as="h2" size="xl" mb="14px">
+          Connecting MetaMask to Binance Smart Chain
+        </Heading>
+
+        <ReactPlayer
+          url="https://www.youtube.com/watch?v=HVH6wpaHcDI"
           preload="auto"
-          width="100%" 
+          width="100%"
           height="500px"
-          style={{  
+          style={{
             padding: 0,
             paddingTop: 0,
             left: 0,
             zIndex: -1,
-            maxHeight: "100%",
-            maxWidth: "100%",
-            objectFit: "cover",
-            objectPosition: "center"
+            maxHeight: '100%',
+            maxWidth: '100%',
+            objectFit: 'cover',
+            objectPosition: 'center',
           }}
         />
         <Divider />

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -417,7 +417,7 @@ const Farms: React.FC<FarmsProps> = (farmsProps) => {
             </Heading>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/farms.svg" alt="Farms" width={600} height={315} />
+            <img src="/images/farms.svg" alt="Farms" width={600} height={315} loading="lazy" decoding="async" />
           </Flex>
         </Flex>
       </PageHeader>

--- a/src/views/Foundation/components/CompositeImage.tsx
+++ b/src/views/Foundation/components/CompositeImage.tsx
@@ -92,17 +92,24 @@ const CompositeImage: React.FC<ComponentProps> = ({ path, attributes, maxHeight 
         maxHeight={maxHeight}
         srcSet={getSrcSet(path, attributes[0].src)}
       />
-      {path !== '/images/foundation/plant/' && attributes.map((image) => (
-        <ImageWrapper key={image.src}>
-          <img src={getImageUrl(path, image.src)} srcSet={getSrcSet(path, image.src)} alt={image.alt} />
-        </ImageWrapper>
-      ))}
-      {path === '/images/foundation/plant/' && attributes.map((image) => (
-        <ImageWrapper key={image.src}>
-          <>
-          </>
-        </ImageWrapper>
-      ))}
+      {path !== '/images/foundation/plant/' &&
+        attributes.map((image) => (
+          <ImageWrapper key={image.src}>
+            <img
+              src={getImageUrl(path, image.src)}
+              srcSet={getSrcSet(path, image.src)}
+              alt={image.alt}
+              loading="lazy"
+              decoding="async"
+            />
+          </ImageWrapper>
+        ))}
+      {path === '/images/foundation/plant/' &&
+        attributes.map((image) => (
+          <ImageWrapper key={image.src}>
+            <></>
+          </ImageWrapper>
+        ))}
     </Wrapper>
   )
 }

--- a/src/views/Gardens/Gardens.tsx
+++ b/src/views/Gardens/Gardens.tsx
@@ -423,7 +423,7 @@ const Gardens: React.FC<GardensProps> = (gardensProps) => {
             </Heading>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/garden.svg" alt="Gardens" width={600} height={315} />
+            <img src="/images/garden.svg" alt="Gardens" width={600} height={315} loading="lazy" decoding="async" />
           </Flex>
         </Flex>
       </PageHeader>

--- a/src/views/Home/components/CompositeImage.tsx
+++ b/src/views/Home/components/CompositeImage.tsx
@@ -93,16 +93,24 @@ const CompositeImage: React.FC<ComponentProps> = ({ path, attributes, maxHeight 
         maxHeight={maxHeight}
         srcSet={getSrcSet(path, attributes[0].src)}
       />
-      {path !== '/images/home/plant/' && attributes.map((image) => (
-        <ImageWrapper key={image.src}>
-          <img src={getImageUrl(path, image.src)} srcSet={getSrcSet(path, image.src)} alt={image.alt} />
-        </ImageWrapper>
-      ))}
-      {path === '/images/home/plant/' && attributes.map((image) => (
-        <ImageWrapper key={image.src}>
-          <Plant />
-        </ImageWrapper>
-      ))}
+      {path !== '/images/home/plant/' &&
+        attributes.map((image) => (
+          <ImageWrapper key={image.src}>
+            <img
+              src={getImageUrl(path, image.src)}
+              srcSet={getSrcSet(path, image.src)}
+              alt={image.alt}
+              loading="lazy"
+              decoding="async"
+            />
+          </ImageWrapper>
+        ))}
+      {path === '/images/home/plant/' &&
+        attributes.map((image) => (
+          <ImageWrapper key={image.src}>
+            <Plant />
+          </ImageWrapper>
+        ))}
     </Wrapper>
   )
 }

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Helmet } from 'react-helmet-async'
 import PageSection from 'components/PageSection'
 import useTheme from 'hooks/useTheme'
 import Container from 'components/Layout/Container'
@@ -12,8 +11,6 @@ import UserBanner from './components/UserBanner'
 import { WedgeTopLeft, InnerWedgeWrapper, OuterWedgeWrapper } from './components/WedgeSvgs'
 import DevelopmentFund from './components/DevelopmentFund'
 import useActiveWeb3React from '../../hooks/useActiveWeb3React'
-import { usePricePlantBusd } from '../../state/farms/hooks'
-import { DEFAULT_META, SITE_NAME, getCanonicalUrl } from '../../config/constants/meta'
 
 const StyledHeroSection = styled(PageSection)`
   padding-top: 16px;
@@ -42,39 +39,11 @@ const UserBannerWrapper = styled(Container)`
 const Home: React.FC = () => {
   const { theme } = useTheme()
   const { account } = useActiveWeb3React()
-  const plantPriceUsd = usePricePlantBusd()
-  const plantPriceUsdDisplay = plantPriceUsd.gt(0)
-    ? `$${plantPriceUsd.toNumber().toLocaleString(undefined, {
-        minimumFractionDigits: 3,
-        maximumFractionDigits: 3,
-      })}`
-    : ''
-
-  const homeTitle = plantPriceUsdDisplay
-    ? `${DEFAULT_META.title} - ${plantPriceUsdDisplay}`
-    : `${DEFAULT_META.title} - Farm $PLANT and help plant trees`
-  const canonical = getCanonicalUrl('/')
 
   const HomeSectionContainerStyles = { margin: '0', width: '100%', maxWidth: '968px' }
 
   return (
     <>
-      <Helmet>
-        <title>{homeTitle}</title>
-        <meta name="description" content={DEFAULT_META.description} />
-        <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1" />
-        <link rel="canonical" href={canonical} />
-        <meta property="og:title" content={DEFAULT_META.title} />
-        <meta property="og:description" content={DEFAULT_META.description} />
-        <meta property="og:image" content={DEFAULT_META.image} />
-        <meta property="og:url" content={canonical} />
-        <meta property="og:type" content="website" />
-        <meta property="og:site_name" content={SITE_NAME} />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={DEFAULT_META.title} />
-        <meta name="twitter:description" content={DEFAULT_META.description} />
-        <meta name="twitter:image" content={DEFAULT_META.image} />
-      </Helmet>
       <StyledHeroSection
         innerProps={{ style: { margin: '0', width: '100%' } }}
         background={

--- a/src/views/Market/components/NftTable/Image.tsx
+++ b/src/views/Market/components/NftTable/Image.tsx
@@ -7,19 +7,18 @@ export interface ImageProps {
 }
 
 const NftImage = styled.span`
-  color: ${({ theme }) => (theme.colors.text)};
+  color: ${({ theme }) => theme.colors.text};
   display: flex;
   align-items: center;
   padding-left: 20px;
 `
 
 const Image: React.FunctionComponent<ImageProps> = ({ images, alt }) => {
-
   const rootPath = `/images/nfts/${images}`
-  
+
   return (
     <NftImage>
-      <img src={rootPath} alt={alt} width={100} />
+      <img src={rootPath} alt={alt} width={100} loading="lazy" decoding="async" />
     </NftImage>
   )
 }

--- a/src/views/Profile/ProfileCreation/Header.tsx
+++ b/src/views/Profile/ProfileCreation/Header.tsx
@@ -20,20 +20,14 @@ const Header: React.FC = () => {
     <Wrapper>
       <Hero>
         <div>
-            <Heading as="h1" scale="xxl" color="secondary">
-              {t('Create your Profile')}
-            </Heading>
-            <Text bold>
-              {t('Creat a unique profile by minting a Gardeners (NFT)and locking it in your profile.')}
-            </Text>
-            <Text bold>
-              {t('This gardeners profile will give you access to special things...')}
-            </Text>
-            <Text color="secondary">
-              {t('Total cost: 2 PLANT')}
-            </Text>
+          <Heading as="h1" scale="xxl" color="secondary">
+            {t('Create your Profile')}
+          </Heading>
+          <Text bold>{t('Creat a unique profile by minting a Gardeners (NFT)and locking it in your profile.')}</Text>
+          <Text bold>{t('This gardeners profile will give you access to special things...')}</Text>
+          <Text color="secondary">{t('Total cost: 2 PLANT')}</Text>
         </div>
-        <img src="/images/teams.svg" alt="Plantswap Teams" width={400} height={210} />
+        <img src="/images/teams.svg" alt="Plantswap Teams" width={400} height={210} loading="lazy" decoding="async" />
       </Hero>
       <Breadcrumbs>
         {steps.map((translationKey, index) => {

--- a/src/views/Project/Project.tsx
+++ b/src/views/Project/Project.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
+import { Helmet } from 'react-helmet-async'
 import Page from 'components/Layout/Page'
 import PageHeader from 'components/PageHeader'
 import { Heading, Text, Flex, EndPage } from '@plantswap/uikit'
 import { useTranslation } from 'contexts/Localization'
+import { PROJECT_FAQ } from 'config/constants/faq'
 import Divider from './components/Divider'
 
 const Project = () => {
@@ -17,48 +19,133 @@ const Project = () => {
               {t('Project')}
             </Heading>
             <Heading scale="lg" color="text">
-              {t('Read the detail of our project and')}<br />
+              {t('Read the detail of our project and')}
+              <br />
               {t('The PlantSwap Development Fund')}
             </Heading>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/project.svg" alt="PlantSwap project — DeFi that funds tree planting and rainforest protection" width={600} height={315} />
+            <img
+              src="/images/project.svg"
+              alt="PlantSwap project — DeFi that funds tree planting and rainforest protection"
+              width={600}
+              height={315}
+              loading="lazy"
+              decoding="async"
+            />
           </Flex>
         </Flex>
       </PageHeader>
       <Page>
-        <Heading as="h2" size="xl" mb="14px">PlantSwap — DeFi on Binance Smart Chain that helps the planet</Heading>
+        <Heading as="h2" size="xl" mb="14px">
+          PlantSwap — DeFi on Binance Smart Chain that helps the planet
+        </Heading>
         <br />
-        <Text>PlantSwap is a yield-farming and AMM platform on Binance Smart Chain (BSC) where users earn the $PLANT token through farms and gardens, and where a share of every transaction funds real-world environmental causes.</Text>
-        <Text>DeFi on BSC is growing fast, but most platforms look the same — the same farms, the same tokenomics, the same dashboards. PlantSwap is built to be different: every swap, every farm, every garden puts the planet first.</Text>
+        <Text>
+          PlantSwap is a yield-farming and AMM platform on Binance Smart Chain (BSC) where users earn the $PLANT token
+          through farms and gardens, and where a share of every transaction funds real-world environmental causes.
+        </Text>
+        <Text>
+          DeFi on BSC is growing fast, but most platforms look the same — the same farms, the same tokenomics, the same
+          dashboards. PlantSwap is built to be different: every swap, every farm, every garden puts the planet first.
+        </Text>
         <br />
-        <Heading as="h2" size="xl" mb="14px">What problems does PlantSwap solve?</Heading>
+        <Heading as="h2" size="xl" mb="14px">
+          What problems does PlantSwap solve?
+        </Heading>
         <br />
-        <Text>Too many BSC DeFi platforms to track — farms, pools, and token prices are scattered across dozens of tabs. PlantSwap brings them together.</Text>
-        <Text>Hard to know your real yield — fee tier, APR, impermanent gain and loss are usually invisible. PlantSwap makes them clear.</Text>
-        <Text>Rug pulls from migrator contracts — PlantSwap has no migrator code, so LP tokens cannot be pulled out from under you.</Text>
-        <Text>DeFi without a mission — PlantSwap donates part of every transaction to environmental non-profits through the Development Fund.</Text>
+        <Text>
+          Too many BSC DeFi platforms to track — farms, pools, and token prices are scattered across dozens of tabs.
+          PlantSwap brings them together.
+        </Text>
+        <Text>
+          Hard to know your real yield — fee tier, APR, impermanent gain and loss are usually invisible. PlantSwap makes
+          them clear.
+        </Text>
+        <Text>
+          Rug pulls from migrator contracts — PlantSwap has no migrator code, so LP tokens cannot be pulled out from
+          under you.
+        </Text>
+        <Text>
+          DeFi without a mission — PlantSwap donates part of every transaction to environmental non-profits through the
+          Development Fund.
+        </Text>
         <br />
-        <Heading as="h2" size="xl" mb="14px">How PlantSwap solves them</Heading>
+        <Heading as="h2" size="xl" mb="14px">
+          How PlantSwap solves them
+        </Heading>
         <br />
         <Text>No migrator contract — your liquidity stays where you put it.</Text>
-        <Text>Detect your other farms and pools across BSC and see your rewards in one place on the <a href="/farms">PlantSwap farms</a> page.</Text>
-        <Text>Clear APR and profitability calculations per day, month, and year — across multiple price scenarios.</Text>
-        <Text>One-click controls to revoke spending approvals and emergency-withdraw from other BSC DeFi projects if something goes wrong.</Text>
+        <Text>
+          Detect your other farms and pools across BSC and see your rewards in one place on the{' '}
+          <a href="/farms">PlantSwap farms</a> page.
+        </Text>
+        <Text>
+          Clear APR and profitability calculations per day, month, and year — across multiple price scenarios.
+        </Text>
+        <Text>
+          One-click controls to revoke spending approvals and emergency-withdraw from other BSC DeFi projects if
+          something goes wrong.
+        </Text>
         <Text>Auto-compound and auto-harvest support on partner farms and pools.</Text>
-        <Text>Stake single tokens in <a href="/gardens">PlantSwap gardens</a> for hands-off, auto-compounding yield in $PLANT.</Text>
-        <Text>Trade any BEP-20 token with low slippage on the <a href="/swap">PlantSwap swap</a>.</Text>
+        <Text>
+          Stake single tokens in <a href="/gardens">PlantSwap gardens</a> for hands-off, auto-compounding yield in
+          $PLANT.
+        </Text>
+        <Text>
+          Trade any BEP-20 token with low slippage on the <a href="/swap">PlantSwap swap</a>.
+        </Text>
         <br />
-        <Heading as="h2" size="xl" mb="14px">🌲 The PlantSwap Development Fund</Heading>
+        <Heading as="h2" size="xl" mb="14px">
+          🌲 The PlantSwap Development Fund
+        </Heading>
         <br />
         <Text>45% 🌲 will go to plant trees 🌲</Text>
         <Text>45% 🔥 will be burned to lower the total supply 🔥</Text>
         <Text>10% 💸 will be kept in treasury to cover operating expense 💸</Text>
         <br />
-        <Text>The Development Fund is governed by the community. Holders of $PLANT can vote on which non-profits to support through the <a href="/foundation">Foundation</a>.</Text>
-        <Text>Every donation is published on-chain — see the full list on the <a href="/developmentFund">Development Fund</a> page.</Text>
-        <Text>Read more about upcoming milestones on the <a href="/roadmap">PlantSwap roadmap</a>.</Text>
-        <br /><br />
+        <Text>
+          The Development Fund is governed by the community. Holders of $PLANT can vote on which non-profits to support
+          through the <a href="/foundation">Foundation</a>.
+        </Text>
+        <Text>
+          Every donation is published on-chain — see the full list on the{' '}
+          <a href="/developmentFund">Development Fund</a> page.
+        </Text>
+        <Text>
+          Read more about upcoming milestones on the <a href="/roadmap">PlantSwap roadmap</a>.
+        </Text>
+        <br />
+        <br />
+
+        <Heading as="h2" size="xl" mb="14px">
+          Frequently asked questions
+        </Heading>
+        <br />
+        {PROJECT_FAQ.map(({ question, answer }) => (
+          <React.Fragment key={question}>
+            <Heading as="h3" size="lg" mb="8px">
+              {question}
+            </Heading>
+            <Text>{answer}</Text>
+            <br />
+          </React.Fragment>
+        ))}
+
+        <Helmet>
+          <script className="faq-schema" type="application/ld+json">
+            {JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'FAQPage',
+              mainEntity: PROJECT_FAQ.map(({ question, answer }) => ({
+                '@type': 'Question',
+                name: question,
+                acceptedAnswer: { '@type': 'Answer', text: answer },
+              })),
+            })}
+          </script>
+        </Helmet>
+
         <Divider />
         <EndPage />
       </Page>

--- a/src/views/Roadmap/Roadmap.tsx
+++ b/src/views/Roadmap/Roadmap.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
+import { Helmet } from 'react-helmet-async'
 import Page from 'components/Layout/Page'
 import PageHeader from 'components/PageHeader'
 import { Heading, Text, Flex, EndPage } from '@plantswap/uikit'
 import { useTranslation } from 'contexts/Localization'
+import { SITE_URL } from 'config/constants/meta'
+import { ROADMAP_LAST_MODIFIED } from 'config/constants/roadmap'
 import Divider from './components/Divider'
 
 const Roadmap = () => {
@@ -17,38 +20,91 @@ const Roadmap = () => {
               {t('Roadmap')}
             </Heading>
             <Heading scale="lg" color="text">
-              {t('Read our roadmap to discover what is next')}<br />
+              {t('Read our roadmap to discover what is next')}
+              <br />
               {t('for the future of PlantSwap.finance and the PLANT token!')}
             </Heading>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/roadmap.svg" alt="PlantSwap roadmap — past milestones and what is next for $PLANT" width={600} height={315} />
+            <img
+              src="/images/roadmap.svg"
+              alt="PlantSwap roadmap — past milestones and what is next for $PLANT"
+              width={600}
+              height={315}
+              loading="lazy"
+              decoding="async"
+            />
           </Flex>
         </Flex>
       </PageHeader>
       <Page>
-        <Heading as="h2" size="xl" mb="14px">Completed milestones</Heading>
+        <Heading as="h2" size="xl" mb="14px">
+          Completed milestones
+        </Heading>
         <Text>Presale of the $PLANT token on Bounce (April 2021)</Text>
-        <Text>Initial liquidity for PLANT/BNB and the first PLANT/BNB and PLANT/BUSD farms and the PLANT garden (April 2021)</Text>
-        <Text>Launch of the PlantSwap Development Fund — 45% of fees fund tree planting, 45% are burned, 10% kept in treasury</Text>
+        <Text>
+          Initial liquidity for PLANT/BNB and the first PLANT/BNB and PLANT/BUSD farms and the PLANT garden (April 2021)
+        </Text>
+        <Text>
+          Launch of the PlantSwap Development Fund — 45% of fees fund tree planting, 45% are burned, 10% kept in
+          treasury
+        </Text>
         <Text>First on-chain donations to the Rainforest Foundation (proof of impact)</Text>
-        <Text>Release of the Barn dashboard — track yield-farming positions across multiple BSC DeFi projects in one place</Text>
+        <Text>
+          Release of the Barn dashboard — track yield-farming positions across multiple BSC DeFi projects in one place
+        </Text>
         <Text>Collectibles and collectibles farms for NFT holders</Text>
         <Text>Community-driven proposals and on-chain voting on the Foundation</Text>
         <Text>Marketplace for peer-to-peer NFT trading</Text>
         <br />
-        <Heading as="h2" size="xl" mb="14px">What is next for PlantSwap</Heading>
-        <Text>Expand <a href="/farms">PlantSwap farms</a> with new BSC DeFi partnerships and cross-chain yield strategies</Text>
-        <Text>Grow <a href="/gardens">PlantSwap gardens</a> with more single-token auto-compounding pools for $PLANT and partner tokens</Text>
-        <Text>Deeper <a href="/foundation">Foundation</a> tooling — recurring donations, new environmental non-profits, and transparent proof-of-burn</Text>
-        <Text>More $PLANT <a href="/pools">pools</a> and integration with trusted BSC DeFi partners</Text>
-        <Text>Continued <a href="/documentation">documentation</a> and developer resources for the PlantSwap ecosystem</Text>
+        <Heading as="h2" size="xl" mb="14px">
+          What is next for PlantSwap
+        </Heading>
+        <Text>
+          Expand <a href="/farms">PlantSwap farms</a> with new BSC DeFi partnerships and cross-chain yield strategies
+        </Text>
+        <Text>
+          Grow <a href="/gardens">PlantSwap gardens</a> with more single-token auto-compounding pools for $PLANT and
+          partner tokens
+        </Text>
+        <Text>
+          Deeper <a href="/foundation">Foundation</a> tooling — recurring donations, new environmental non-profits, and
+          transparent proof-of-burn
+        </Text>
+        <Text>
+          More $PLANT <a href="/pools">pools</a> and integration with trusted BSC DeFi partners
+        </Text>
+        <Text>
+          Continued <a href="/documentation">documentation</a> and developer resources for the PlantSwap ecosystem
+        </Text>
         <Text>Smart contract audits and security reviews for all new contracts</Text>
         <Text>Cross-chain compatibility — beyond BSC</Text>
-        <Text>Expanded <a href="/market">NFT marketplace</a> features: auctions, offers, and partner collections</Text>
+        <Text>
+          Expanded <a href="/market">NFT marketplace</a> features: auctions, offers, and partner collections
+        </Text>
         <br />
-        <Text>Have a feature request or want to contribute to the roadmap? Open a proposal in the <a href="/foundation">Foundation</a> or reach out on the <a href="/contact-us">contact page</a>.</Text>
-        <br /><br />
+        <Text>
+          Have a feature request or want to contribute to the roadmap? Open a proposal in the{' '}
+          <a href="/foundation">Foundation</a> or reach out on the <a href="/contact-us">contact page</a>.
+        </Text>
+        <br />
+        <br />
+
+        <Helmet>
+          <script className="article-schema" type="application/ld+json">
+            {JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'Article',
+              headline: 'PlantSwap roadmap — past milestones and what is next for $PLANT',
+              datePublished: '2021-04-01',
+              dateModified: ROADMAP_LAST_MODIFIED,
+              author: { '@type': 'Organization', name: 'PlantSwap', url: SITE_URL },
+              image: `${SITE_URL}/images/roadmap.svg`,
+              mainEntityOfPage: `${SITE_URL}/roadmap`,
+            })}
+          </script>
+        </Helmet>
+
         <Divider />
         <EndPage />
       </Page>

--- a/src/views/Teams/components/TeamHeader.tsx
+++ b/src/views/Teams/components/TeamHeader.tsx
@@ -15,23 +15,17 @@ const TeamHeader = () => {
     <>
       {showProfileCallout && <NoProfileCard />}
       <HeaderWrapper>
-          <Hero>
-            <div>
+        <Hero>
+          <div>
             <Heading as="h1" scale="xxl" color="secondary">
               {t('Teams & Profiles')}
             </Heading>
-            <Text bold>
-              {t('Have a look at the different Gardeners Teams')}
-            </Text>
-            <Text bold>
-              {t('Each month we donate funds to ecological')}
-            </Text>
-            <Text bold>
-              {t('foundations in line with these teams names & descriptions.')}
-            </Text>
-            </div>
-            <img src="/images/teams.svg" alt="Plantswap Teams" width={400} height={210} />
-          </Hero>
+            <Text bold>{t('Have a look at the different Gardeners Teams')}</Text>
+            <Text bold>{t('Each month we donate funds to ecological')}</Text>
+            <Text bold>{t('foundations in line with these teams names & descriptions.')}</Text>
+          </div>
+          <img src="/images/teams.svg" alt="Plantswap Teams" width={400} height={210} loading="lazy" decoding="async" />
+        </Hero>
       </HeaderWrapper>
     </>
   )

--- a/src/views/Tree/Tree.tsx
+++ b/src/views/Tree/Tree.tsx
@@ -5,7 +5,6 @@ import { Heading, Text, Flex, EndPage } from '@plantswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import Divider from './components/Divider'
 
-
 const Tree = () => {
   const { t } = useTranslation()
 
@@ -18,29 +17,39 @@ const Tree = () => {
               {t('Tree Token')}
             </Heading>
             <Heading scale="lg" color="text">
-              {t('Decentralize gouvernance for the')}<br />
+              {t('Decentralize gouvernance for the')}
+              <br />
               {t('PlantSwap Development Fund')}
             </Heading>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/tree.svg" alt="Gardens" width={250} height={250} />
+            <img src="/images/tree.svg" alt="Gardens" width={250} height={250} loading="lazy" decoding="async" />
           </Flex>
         </Flex>
       </PageHeader>
       <Page>
-          <Heading as="h2" size="xl" mb="14px">Why holding the Tree token?</Heading>
-            <br />
-            <Text>-Vote on the allocation in donation to each organisme</Text>
-            <Text>-Suggest new new non profits and allocation</Text>
-            <Text>-Vote on tokenomic of the platform, futur farms and pools</Text>
-            <Text>-Vote on the development priority</Text>
-            <br />
-          <Heading as="h2" size="xl" mb="14px">A decentralized autonomous foundation, this is our goal!</Heading>
-            <br />
-            <Text>A word of caution, this entire platform is a real world experiment, this project is in current development (dev in prod), invest at your own risk.</Text>
-            <Text>If you want to contribute one way or a other to this project, please contact us on Telegram or Twitter.</Text>
-            <Text>Let&apos;s make the world a better place all together.</Text>
-          <br />
+        <Heading as="h2" size="xl" mb="14px">
+          Why holding the Tree token?
+        </Heading>
+        <br />
+        <Text>-Vote on the allocation in donation to each organisme</Text>
+        <Text>-Suggest new new non profits and allocation</Text>
+        <Text>-Vote on tokenomic of the platform, futur farms and pools</Text>
+        <Text>-Vote on the development priority</Text>
+        <br />
+        <Heading as="h2" size="xl" mb="14px">
+          A decentralized autonomous foundation, this is our goal!
+        </Heading>
+        <br />
+        <Text>
+          A word of caution, this entire platform is a real world experiment, this project is in current development
+          (dev in prod), invest at your own risk.
+        </Text>
+        <Text>
+          If you want to contribute one way or a other to this project, please contact us on Telegram or Twitter.
+        </Text>
+        <Text>Let&apos;s make the world a better place all together.</Text>
+        <br />
         <Divider />
         <EndPage />
       </Page>

--- a/src/views/VerticalGardens/index.tsx
+++ b/src/views/VerticalGardens/index.tsx
@@ -222,7 +222,14 @@ const Pools: React.FC = () => {
             </Heading>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/verticalGardens.svg" alt="Gardens" width={600} height={315} />
+            <img
+              src="/images/verticalGardens.svg"
+              alt="Gardens"
+              width={600}
+              height={315}
+              loading="lazy"
+              decoding="async"
+            />
           </Flex>
         </Flex>
       </PageHeader>

--- a/src/views/Vote/Vote.tsx
+++ b/src/views/Vote/Vote.tsx
@@ -16,23 +16,19 @@ const Vote = () => {
               {t('Vote')}
             </Heading>
             <Heading scale="lg" color="text">
-              {t('Vote on proposals to chose the future of PlantSwap')}<br />
+              {t('Vote on proposals to chose the future of PlantSwap')}
+              <br />
               {t('when you hold PLANT in your walle')}
             </Heading>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/roadmap.svg" alt="Gardens" width={600} height={315} />
+            <img src="/images/roadmap.svg" alt="Gardens" width={600} height={315} loading="lazy" decoding="async" />
           </Flex>
         </Flex>
       </PageHeader>
-        <iframe 
-          title="Snapshot Voting" 
-          src="https://snapshot.org/#/plantswap.eth" 
-          width="100%" 
-          height="900px"
-        />
-        <Divider />
-        <EndPage />
+      <iframe title="Snapshot Voting" src="https://snapshot.org/#/plantswap.eth" width="100%" height="900px" />
+      <Divider />
+      <EndPage />
     </>
   )
 }


### PR DESCRIPTION
## Summary

Closes the gaps from the SEO audit:
- every route now gets meta (previously /swap /add /remove /find /liquidity /vote /foundation /foundation/* /voting/* silently fell back to the bare `index.html`)
- titles are stable — no live `$PLANT` price appended
- thin pages (`/vote`, `/documentation`) and unknown URLs (`/foo`) are `noindex,nofollow`
- invalid `SearchAction` JSON-LD removed; FAQPage on `/project`, Article on `/roadmap`, BreadcrumbList on `/foundation/proposal/:id`, `/teams/:id`, `/voting/proposal/:id`
- sitemap is now build-generated with `<lastmod>`
- lazy-loading on below-the-fold images; Netlify security/cache headers

## Changes (9 commits)

1. `chore(seo): extract PageMeta, hoist into App, drop live price from title`
2. `feat(seo): expand getCustomMeta for all routes, add per-route OG images`
3. `fix(seo): drop invalid SearchAction schema from index.html`
4. `feat(seo): add FAQPage schema on /project`
5. `feat(seo): add Article schema on /roadmap`
6. `feat(seo): add sitemap generator + postbuild hook`
7. `feat(seo): sync public/sitemap.xml with generated output`
8. `fix(seo): update robots.txt to match noindex scope`
9. `perf(cwv): lazy-load below-fold images, add Netlify security/cache headers`

## How to verify

```bash
yarn install
yarn build              # build/sitemap.xml should appear with <lastmod>
yarn start              # then visit each route, view source
```

Per-route checks (curl after `yarn start`):

| Route | Expected `<title>` | `robots` |
|---|---|---|
| `/` | `Home \| PlantSwap` | `index, follow, ...` |
| `/swap` | `Swap \| PlantSwap` | `index, follow, ...` |
| `/add` | `Add Liquidity \| PlantSwap` | `noindex, nofollow` |
| `/foundation/proposal/1` | `Foundation Proposal \| PlantSwap` | `index, follow, ...` |
| `/vote` | `Vote \| PlantSwap` | `noindex, nofollow` |
| `/documentation` | `Documentation \| PlantSwap` | `noindex, nofollow` |
| `/foo-bar-baz` (404) | `PlantSwap` | `noindex, nofollow` |
| `/swap/BUSD` | `Swap Output \| PlantSwap` | `noindex, nofollow` |

JSON-LD:
- `/project` → `"@type":"FAQPage"` with 6 Question entries
- `/foundation/proposal/1` → `"@type":"BreadcrumbList"` with 3 ListItem entries
- `/roadmap` → `"@type":"Article"` with `dateModified`

## Deferred (separate PRs)

- **#2 SSR / prerender** — CRA + React 17 has no SSR pipeline. Needs `react-snap` or Next.js migration; multi-week infra change with cascading SEO consequences. Document the steps in the issue tracker before attempting.
- **#7 hreflang / i18n URLs** — site is English-only at the URL level; adding `hreflang` for non-existent translated routes would mislead Google. Defer until at least one full non-English locale ships to production.
- **Raster 1200×630 OG images** — per-route OG fields point at existing section SVGs as placeholders. Converting to PNG needs a Playwright render script.
- **3D code-splitting + Lighthouse tuning** — needs production profiling.

## Pre-existing issues (not caused by this PR)

`yarn lint` reports 9 errors and 1 warning in files this PR does not touch (test modules, 3D code, search modal, foundation cast vote modal). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)