### PR TITLE
fix: drop stale react-scripts refs and bump Dockerfile node to 24 (#31)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:24
 
 WORKDIR /docker
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "start": "vite",
     "build": "vite build && yarn sitemap:generate",
     "preview": "vite preview",
-    "test": "react-scripts test",
     "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx}\"",
     "format:write": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",

--- a/scripts/generateSitemap.ts
+++ b/scripts/generateSitemap.ts
@@ -1,7 +1,7 @@
 /**
  * Generates build/sitemap.xml at build time.
  *
- * Run automatically after `react-scripts build` via the chained `build` script
+ * Run automatically after `vite build` via the chained `build` script
  * in package.json. Also runnable directly via `yarn sitemap:generate`.
  *
  * Source of truth for which URLs to include is the INDEXABLE_ROUTES table

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="react-scripts" />
+/// <reference types="vite/client" />
 
 interface Window {
   ethereum?: {


### PR DESCRIPTION
## Summary
- Dockerfile: bump `FROM node:12` → `FROM node:24`. Node 12 is EOL since 2022 and its bundled OpenSSL is old enough that modern TLS handshakes (e.g. the npm registry's `ERR_OSSL_PEER_KEY_UPDATE` class of failures) require the `--openssl-legacy-provider` workaround that the issue calls out. Node 24 matches `.nvmrc` and ships a current OpenSSL.
- `package.json`: drop the `"test": "react-scripts test"` script — `react-scripts` is no longer a dependency after the Vite migration in `a6a9d9b`. The script was already non-functional.
- `src/react-app-env.d.ts`: switch the ambient type reference from `react-scripts` to `vite/client` so the file matches the actual build pipeline.
- `scripts/generateSitemap.ts`: update the stale header comment that referenced `react-scripts build` to `vite build`.

## Test plan
- [x] `yarn build` succeeds on this branch (vite build + sitemap generation both complete; only pre-existing chunk-size and dashjs CommonJS warnings remain).
- [ ] `yarn lint` is broken on master too (ESLint 10 expects `eslint.config.js`; the repo still ships `.eslintrc.js`). Out of scope for this PR — happy to file a follow-up if desired.

## Out of scope
- Wiring up a real test runner. Test files exist under `src/__tests__/` and `src/hooks/useApproveConfirmTransaction.test.tsx`, but `jest` is not a dependency, and adding one is a larger conversation than this SSL cleanup. Left the `test` script removed so `yarn test` no longer points at a missing binary.

Fixes #31