### PR TITLE
feat: Add Resend-backed contact form on /contact-us

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,15 @@ DATABASE_URL="postgresql://user:password@host.neon.tech/dbname?sslmode=require"
 # Dev points at the local mock service; production must point at the real host.
 # Example: REACT_APP_COLLECTIBLES_API_URL="https://collectibles.example.com"
 REACT_APP_COLLECTIBLES_API_URL="http://localhost:3003"
+
+# Resend — transactional email for the /contact-us form (Netlify function only).
+# These are SERVER-side env vars; they are read by `functions/contact-us.js` via
+# process.env. Set them in the Netlify dashboard (or in `netlify.toml`
+# `[functions.environment]`) — they are NOT bundled into the client and should
+# NOT be added to .env.development / .env.production.
+# Get an API key at https://resend.com/api-keys
+RESEND_API_KEY=""
+CONTACT_TO_EMAIL="plantswapfinance@gmail.com"
+# Override once a custom domain is verified in Resend (SPF + DKIM in DNS).
+# Default `onboarding@resend.dev` only delivers to the Resend account owner's inbox.
+CONTACT_FROM_EMAIL="onboarding@resend.dev"

--- a/functions/contact-us.js
+++ b/functions/contact-us.js
@@ -1,0 +1,64 @@
+const { Resend } = require('resend')
+
+const TO_EMAIL = process.env.CONTACT_TO_EMAIL || 'plantswapfinance@gmail.com'
+const FROM_EMAIL = process.env.CONTACT_FROM_EMAIL || 'onboarding@resend.dev'
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/**
+ * Netlify function for the public `/contact-us` form.
+ * Sends submissions via Resend. Same-origin only — no CORS headers.
+ */
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+  }
+
+  let payload
+  try {
+    payload = JSON.parse(event.body || '{}')
+  } catch (err) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON' }) }
+  }
+
+  const { clientName, email, sujet, message, honeypot } = payload || {}
+
+  // Honeypot — silently accept so bots don't retry.
+  if (honeypot) {
+    return { statusCode: 200, body: JSON.stringify({ ok: true }) }
+  }
+
+  if (!clientName || typeof clientName !== 'string' || !clientName.trim()) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Name is required' }) }
+  }
+  if (!email || typeof email !== 'string' || !EMAIL_RE.test(email)) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Valid email is required' }) }
+  }
+  if (!sujet || typeof sujet !== 'string' || !sujet.trim()) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Subject is required' }) }
+  }
+  if (!message || typeof message !== 'string' || !message.trim()) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Message is required' }) }
+  }
+
+  const apiKey = process.env.RESEND_API_KEY
+  if (!apiKey) {
+    console.error('contact-us: RESEND_API_KEY is not set')
+    return { statusCode: 500, body: JSON.stringify({ error: 'Email service not configured' }) }
+  }
+
+  const resend = new Resend(apiKey)
+  try {
+    await resend.emails.send({
+      from: FROM_EMAIL,
+      to: TO_EMAIL,
+      replyTo: email,
+      subject: `[Contact] ${sujet}`,
+      text: `From: ${clientName} <${email}>\nSubject: ${sujet}\n\n${message}`,
+    })
+    return { statusCode: 200, body: JSON.stringify({ ok: true }) }
+  } catch (error) {
+    console.error('contact-us: resend failed', error)
+    return { statusCode: 500, body: JSON.stringify({ error: 'Failed to send message' }) }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react-transition-group": "^4.4.1",
     "react-window": "^2.0.0",
     "remark-gfm": "^4.0.0",
+    "resend": "^4.0.0",
     "split-grid": "^1.0.11",
     "styled-components": "^6.0.0",
     "swiper": "^14.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -249,6 +249,7 @@ const App: React.FC = () => {
               <Route path="/roadmap" element={<Roadmap />} />
               <Route path="/tree" element={<Tree />} />
               <Route path="/vote" element={<Vote />} />
+              <Route path="/contact-us" element={<ContactUs />} />
               <Route path="/documentation" element={<Documentation />} />
 
               {/* These components read their route params/navigation via hooks */}

--- a/src/components/Menu/config.ts
+++ b/src/components/Menu/config.ts
@@ -83,8 +83,7 @@ const config: (t: ContextApi['t']) => MenuEntry[] = (t) => [
     items: [
       {
         label: t('Contact'),
-        href: 'https://plantswap.finance/contact-us',
-        target: '_blank',
+        href: '/contact-us',
       },
       {
         label: t('Github'),

--- a/src/components/MenuDev/config.ts
+++ b/src/components/MenuDev/config.ts
@@ -96,6 +96,10 @@ const config: (t: ContextApi['t']) => MenuEntry[] = (t) => [
     icon: 'MoreIcon',
     items: [
       {
+        label: t('Contact'),
+        href: '/contact-us',
+      },
+      {
         label: t('Github'),
         href: 'https://github.com/plantswapfinance',
       },

--- a/src/utils/calls/contact.ts
+++ b/src/utils/calls/contact.ts
@@ -1,0 +1,12 @@
+const submitContact = (data) => {
+  return fetch('/.netlify/functions/contact-us', {
+    body: JSON.stringify(data),
+    method: 'POST',
+  }).then((response) => {
+    return response.json()
+  })
+}
+
+export default {
+  submitContact,
+}

--- a/src/views/ContactUs/ContactUs.tsx
+++ b/src/views/ContactUs/ContactUs.tsx
@@ -1,61 +1,61 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
-import emailjs from '@emailjs/browser'
 import Page from 'components/Layout/Page'
 import PageHeader from 'components/PageHeader'
 import { Heading, Flex, EndPage, Text, Input, Button } from '@plantswap/uikit'
 import { useTranslation } from 'contexts/Localization'
+import contactApi from 'utils/calls/contact'
 import Divider from './components/Divider'
-import { getContactFormErrors, FormErrors } from './helper'
 
 interface ContactFormState {
   clientName: string
   email: string
   sujet: string
   message: string
+  honeypot: string
+}
+
+const initialState: ContactFormState = {
+  clientName: '',
+  email: '',
+  sujet: '',
+  message: '',
+  honeypot: '',
 }
 
 const ContactUs = () => {
   const { t } = useTranslation()
+  const [state, setState] = useState<ContactFormState>(initialState)
   const [send, setSend] = useState(false)
-  const [state, setState] = useState<ContactFormState>({
-    clientName: '',
-    email: '',
-    sujet: '',
-    message: '',
-  })
-  // eslint-disable-next-line
-  const { clientName, email, sujet, message } = state
-  // eslint-disable-next-line
-  const [fieldsState, setFieldsState] = useState<{ [key: string]: boolean }>({})
-  const formErrors = getContactFormErrors(state)
+  const [sending, setSending] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  const handleChange = (e: any) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target
     setState((prevState) => ({ ...prevState, [name]: value }))
   }
 
-  const clearState = () =>
-    setState({
-      clientName: '',
-      email: '',
-      sujet: '',
-      message: '',
-    })
+  const clearState = () => setState(initialState)
 
-  const handleSubmit = (e: any) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    emailjs
-      .sendForm('service_2heraoe', 'template_revj3os', e.target, { publicKey: 'user_LncbCjsg709omIRnMnAH3' })
-      .then(
-      () => {
+    if (sending) return
+    setSending(true)
+    setErrorMessage(null)
+    try {
+      const result = await contactApi.submitContact(state)
+      if (result && result.ok) {
         clearState()
         setSend(true)
-      },
-      (error) => {
-        console.error(error.text)
-      },
-    )
+      } else {
+        setErrorMessage(result && result.error ? result.error : 'Failed to send your message')
+      }
+    } catch (err) {
+      console.error('contact-us submit failed', err)
+      setErrorMessage('Failed to send your message')
+    } finally {
+      setSending(false)
+    }
   }
 
   return (
@@ -85,32 +85,43 @@ const ContactUs = () => {
             </Text>
           </Flex>
         )}
+        {errorMessage && (
+          <Flex alignItems="center" mb="16px">
+            <Text color="failure" mr="16px">
+              {t(errorMessage)}
+            </Text>
+          </Flex>
+        )}
         <form id="form" onSubmit={handleSubmit}>
+          <HoneypotField>
+            <label htmlFor="honeypot">Leave this field empty</label>
+            <input
+              type="text"
+              id="honeypot"
+              name="honeypot"
+              value={state.honeypot}
+              onChange={handleChange}
+              tabIndex={-1}
+              autoComplete="off"
+              aria-hidden="true"
+            />
+          </HoneypotField>
+
           <Flex mb="16px">
             <Text color="textSubtle" mr="16px">
               {t('Your name')}
             </Text>
-            <Input
-              type="hidden"
-              name="emailSubject"
-              id="emailSubject"
-              value={`Subject: ${sujet} From: ${clientName}`}
-            />
-            <Input
-              type="hidden"
-              name="emailBody"
-              id="emailBody"
-              value={`Subject: ${sujet}\n
-              From: ${clientName}\n
-              Email: ${email}\n
-              Message: ${message}\n
-              \n\n\n
-              Sent from ESportsCentral.ca`}
-            />
           </Flex>
           <Flex mb="16px">
-            <Input type="text" name="clientName" id="clientName" required onChange={handleChange} />
-            {formErrors.clientName && fieldsState.clientName && <FormErrors errors={formErrors.clientName} />}
+            <Input
+              type="text"
+              name="clientName"
+              id="clientName"
+              value={state.clientName}
+              required
+              onChange={handleChange}
+              disabled={sending}
+            />
           </Flex>
           <Flex mb="16px">
             <Text color="textSubtle" mr="16px">
@@ -118,8 +129,15 @@ const ContactUs = () => {
             </Text>
           </Flex>
           <Flex mb="16px">
-            <Input type="text" name="email" id="email" required onChange={handleChange} />
-            {formErrors.email && fieldsState.email && <FormErrors errors={formErrors.email} />}
+            <Input
+              type="email"
+              name="email"
+              id="email"
+              value={state.email}
+              required
+              onChange={handleChange}
+              disabled={sending}
+            />
           </Flex>
           <Flex mb="16px">
             <Text color="textSubtle" mr="16px">
@@ -127,34 +145,36 @@ const ContactUs = () => {
             </Text>
           </Flex>
           <Flex mb="16px">
-            <Input type="text" name="sujet" id="sujet" required onChange={handleChange} />
-            {formErrors.sujet && fieldsState.sujet && <FormErrors errors={formErrors.sujet} />}
+            <Input
+              type="text"
+              name="sujet"
+              id="sujet"
+              value={state.sujet}
+              required
+              onChange={handleChange}
+              disabled={sending}
+            />
           </Flex>
-          {clientName && (
-            <>
-              <Flex mb="16px">
-                <Text color="textSubtle" mr="16px">
-                  {t('Message')}
-                </Text>
-              </Flex>
-              <Flex mb="16px">
-                <Textarea name="message" id="message" value={message} required onChange={handleChange} />
-                {formErrors.message && fieldsState.message && <FormErrors errors={formErrors.message} />}
-              </Flex>
-              <Flex alignItems="center" mb="16px">
-                <Button type="submit" id="button" value="Send Email" onClick={() => handleSubmit} disabled={send}>
-                  {t('Send your message')}
-                </Button>
-              </Flex>
-            </>
-          )}
-          {send && (
-            <Flex alignItems="center" mb="16px">
-              <Text color="success" mr="16px">
-                {t('Your message has been sent!')}
-              </Text>
-            </Flex>
-          )}
+          <Flex mb="16px">
+            <Text color="textSubtle" mr="16px">
+              {t('Message')}
+            </Text>
+          </Flex>
+          <Flex mb="16px">
+            <Textarea
+              name="message"
+              id="message"
+              value={state.message}
+              required
+              onChange={handleChange}
+              disabled={sending}
+            />
+          </Flex>
+          <Flex alignItems="center" mb="16px">
+            <Button type="submit" id="button" value="Send Email" disabled={sending || send}>
+              {sending ? t('Sending...') : t('Send your message')}
+            </Button>
+          </Flex>
         </form>
         <Divider />
         <EndPage />
@@ -174,9 +194,10 @@ const Textarea = styled.textarea`
   height: 200px;
   font-size: 16px;
   outline: 0;
-  padding: 0 16px;
+  padding: 16px;
   width: 100%;
   border: 1px solid ${({ theme }) => theme.colors.inputSecondary};
+  resize: vertical;
 
   &::placeholder {
     color: ${({ theme }) => theme.colors.textSubtle};
@@ -192,4 +213,14 @@ const Textarea = styled.textarea`
   &:focus:not(:disabled) {
     box-shadow: ${({ theme }) => theme.shadows.focus};
   }
+`
+
+const HoneypotField = styled.div`
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
 `

--- a/src/views/ContactUs/ContactUs.tsx
+++ b/src/views/ContactUs/ContactUs.tsx
@@ -91,7 +91,7 @@ const ContactUs = () => {
             </Text>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/plant-question.svg" alt="Contact" width={400} height={400} loading="lazy" decoding="async" />
+            <img src="/images/roadmap.svg" alt="Contact" width={400} height={400} loading="lazy" decoding="async" />
           </Flex>
         </Flex>
       </PageHeader>

--- a/src/views/ContactUs/ContactUs.tsx
+++ b/src/views/ContactUs/ContactUs.tsx
@@ -91,7 +91,7 @@ const ContactUs = () => {
             </Text>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/help.svg" alt="Contact" width={400} height={400} loading="lazy" decoding="async" />
+            <img src="/images/plant-question.svg" alt="Contact" width={400} height={400} loading="lazy" decoding="async" />
           </Flex>
         </Flex>
       </PageHeader>

--- a/src/views/ContactUs/ContactUs.tsx
+++ b/src/views/ContactUs/ContactUs.tsx
@@ -2,7 +2,22 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import Page from 'components/Layout/Page'
 import PageHeader from 'components/PageHeader'
-import { Heading, Flex, EndPage, Text, Input, Button } from '@plantswap/uikit'
+import {
+  Heading,
+  Flex,
+  EndPage,
+  Text,
+  Input,
+  Button,
+  Card,
+  CardBody,
+  Link,
+  Box,
+  HelpIcon,
+  TeamPlayerIcon,
+  MegaphoneIcon,
+  VerifiedIcon,
+} from '@plantswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import contactApi from 'utils/calls/contact'
 import Divider from './components/Divider'
@@ -64,20 +79,98 @@ const ContactUs = () => {
         <Flex justifyContent="space-between" flexDirection={['column', null, null, 'row']}>
           <Flex flex="1" flexDirection="column" mr={['8px', 0]}>
             <Heading as="h1" scale="xxl" color="secondary" mb="24px">
-              {t('Contact-Us')}
+              {t('Get in touch')}
             </Heading>
-            <Heading scale="lg" color="text">
-              {t('Learn how to connect your wallet to Plantswap')}
-              <br />
+            <Heading as="h2" scale="lg" color="text" mb="16px">
+              {t('We are a small team building a DeFi platform that funds tree planting and rainforest protection.')}
             </Heading>
+            <Text color="textSubtle">
+              {t(
+                'Use the form below for partnerships, press, support, and security reports. We read every message and usually reply within a few business days.',
+              )}
+            </Text>
           </Flex>
           <Flex flex="1" height="fit-content" justifyContent="center" alignItems="center" mt={['24px', null, '0']}>
-            <img src="/images/roadmap.svg" alt="Gardens" width={600} height={315} loading="lazy" decoding="async" />
+            <img src="/images/help.svg" alt="Contact" width={400} height={400} loading="lazy" decoding="async" />
           </Flex>
         </Flex>
       </PageHeader>
 
       <Page>
+        <SectionTitle>{t('What can we help you with?')}</SectionTitle>
+        <CardGrid>
+          <ReasonCard>
+            <CardBody>
+              <IconCircle>
+                <HelpIcon width="24px" color="secondary" />
+              </IconCircle>
+              <Heading scale="md" mb="8px">
+                {t('Wallet & swap support')}
+              </Heading>
+              <Text color="textSubtle" fontSize="14px">
+                {t(
+                  'Stuck swap, missing token, RPC errors, or transaction that will not confirm. Include your wallet address and a transaction hash when relevant.',
+                )}
+              </Text>
+            </CardBody>
+          </ReasonCard>
+
+          <ReasonCard>
+            <CardBody>
+              <IconCircle>
+                <TeamPlayerIcon width="24px" color="secondary" />
+              </IconCircle>
+              <Heading scale="md" mb="8px">
+                {t('Partnerships & listings')}
+              </Heading>
+              <Text color="textSubtle" fontSize="14px">
+                {t(
+                  'Token listings, farms or gardens integrations, cross-chain bridges, environmental non-profits, and other collaboration proposals.',
+                )}
+              </Text>
+            </CardBody>
+          </ReasonCard>
+
+          <ReasonCard>
+            <CardBody>
+              <IconCircle>
+                <MegaphoneIcon width="24px" color="secondary" />
+              </IconCircle>
+              <Heading scale="md" mb="8px">
+                {t('Press & media')}
+              </Heading>
+              <Text color="textSubtle" fontSize="14px">
+                {t(
+                  'Interviews, articles, podcasts, and brand assets. Reach out with your outlet, deadline, and angle and we will get back quickly.',
+                )}
+              </Text>
+            </CardBody>
+          </ReasonCard>
+
+          <ReasonCard>
+            <CardBody>
+              <IconCircle>
+                <VerifiedIcon width="24px" color="secondary" />
+              </IconCircle>
+              <Heading scale="md" mb="8px">
+                {t('Security disclosures')}
+              </Heading>
+              <Text color="textSubtle" fontSize="14px">
+                {t(
+                  'Found a vulnerability in our contracts or front end? Please report it privately. Do not post details publicly until we have responded.',
+                )}
+              </Text>
+            </CardBody>
+          </ReasonCard>
+        </CardGrid>
+
+        <Divider />
+
+        <SectionTitle>{t('Send us a message')}</SectionTitle>
+        <Text color="textSubtle" mb="24px">
+          {t('Fill in the form and we will reply to the email you provide. Required fields are marked by your browser.')}
+        </Text>
+
         {send && (
           <Flex alignItems="center" mb="16px">
             <Text color="success" mr="16px">
@@ -176,6 +269,34 @@ const ContactUs = () => {
             </Button>
           </Flex>
         </form>
+
+        <Divider />
+
+        <SectionTitle>{t('Other ways to reach us')}</SectionTitle>
+        <Text color="textSubtle" mb="16px">
+          {t('Prefer a public channel? Find us here:')}
+        </Text>
+        <Box>
+          <Link external href="https://github.com/plantswapfinance">
+            GitHub
+          </Link>
+          <Text as="span" color="textSubtle" mx="8px">
+            ·
+          </Text>
+          <Link external href="https://plantswapfinance.medium.com">
+            {t('Blog')}
+          </Link>
+          <Text as="span" color="textSubtle" mx="8px">
+            ·
+          </Text>
+          <Link href="/roadmap">{t('Roadmap')}</Link>
+        </Box>
+        <Box mt="16px">
+          <Text color="textSubtle" fontSize="14px">
+            {t('We typically respond within 2–3 business days. For urgent security issues, mark the subject with "Security".')}
+          </Text>
+        </Box>
+
         <Divider />
         <EndPage />
       </Page>
@@ -223,4 +344,36 @@ const HoneypotField = styled.div`
   height: 1px;
   overflow: hidden;
   opacity: 0;
+`
+
+const SectionTitle = styled(Heading).attrs({ as: 'h2', scale: 'xl' })`
+  color: ${({ theme }) => theme.colors.secondary};
+  margin-bottom: 16px;
+`
+
+const CardGrid = styled(Box)`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  margin-bottom: 32px;
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    grid-template-columns: 1fr 1fr;
+  }
+`
+
+const ReasonCard = styled(Card)`
+  background: ${({ theme }) => theme.colors.background};
+  border: 1px solid ${({ theme }) => theme.colors.cardBorder};
+`
+
+const IconCircle = styled.div`
+  align-items: center;
+  background: ${({ theme }) => theme.colors.tertiary};
+  border-radius: 999px;
+  display: inline-flex;
+  height: 48px;
+  justify-content: center;
+  margin-bottom: 16px;
+  width: 48px;
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -3193,6 +3193,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-email/render@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@react-email/render@npm:1.1.2"
+  dependencies:
+    html-to-text: "npm:^9.0.5"
+    prettier: "npm:^3.5.3"
+    react-promise-suspense: "npm:^0.3.4"
+  peerDependencies:
+    react: ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+  checksum: 10c0/def0039a24b797d962d7dcb3a3401c093aa0115545284e00863de4066a826a3e4977b8f2c65b1f3bf77352bee5595e0dedf166ea52467dcb7080e14785e1c3ac
+  languageName: node
+  linkType: hard
+
 "@react-pdf/yoga@npm:^2.0.4":
   version: 2.0.4
   resolution: "@react-pdf/yoga@npm:2.0.4"
@@ -3483,6 +3497,16 @@ __metadata:
   version: 0.4.1
   resolution: "@sec-ant/readable-stream@npm:0.4.1"
   checksum: 10c0/64e9e9cf161e848067a5bf60cdc04d18495dc28bb63a8d9f8993e4dd99b91ad34e4b563c85de17d91ffb177ec17a0664991d2e115f6543e73236a906068987af
+  languageName: node
+  linkType: hard
+
+"@selderee/plugin-htmlparser2@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@selderee/plugin-htmlparser2@npm:0.11.0"
+  dependencies:
+    domhandler: "npm:^5.0.3"
+    selderee: "npm:^0.11.0"
+  checksum: 10c0/e938ba9aeb31a9cf30dcb2977ef41685c598bf744bedc88c57aa9e8b7e71b51781695cf99c08aac50773fd7714eba670bd2a079e46db0788abe40c6d220084eb
   languageName: node
   linkType: hard
 
@@ -7443,7 +7467,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deepmerge@npm:^4.2.2":
+"deepmerge@npm:^4.2.2, deepmerge@npm:^4.3.1":
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
   checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
@@ -7964,7 +7988,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.2.0":
+"entities@npm:^4.2.0, entities@npm:^4.4.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 10c0/5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
@@ -8968,6 +8992,13 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
+  languageName: node
+  linkType: hard
+
+"fast-deep-equal@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "fast-deep-equal@npm:2.0.1"
+  checksum: 10c0/1602e0d6ed63493c865cc6b03f9070d6d3926e8cd086a123060b58f80a295f3f08b1ecfb479ae7c45b7fd45535202aea7cf5b49bc31bffb81c20b1502300be84
   languageName: node
   linkType: hard
 
@@ -10016,10 +10047,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-to-text@npm:^9.0.5":
+  version: 9.0.5
+  resolution: "html-to-text@npm:9.0.5"
+  dependencies:
+    "@selderee/plugin-htmlparser2": "npm:^0.11.0"
+    deepmerge: "npm:^4.3.1"
+    dom-serializer: "npm:^2.0.0"
+    htmlparser2: "npm:^8.0.2"
+    selderee: "npm:^0.11.0"
+  checksum: 10c0/5d2c77b798cf88a81b1da2fc1ea1a3b3e2ff49fe5a3d812392f802fff18ec315cf0969bd7846ef2eb7df8c37f463bc63e8cbdcf84e42696c6f3e15dfa61cdf4f
+  languageName: node
+  linkType: hard
+
 "html-url-attributes@npm:^3.0.0":
   version: 3.0.1
   resolution: "html-url-attributes@npm:3.0.1"
   checksum: 10c0/496e4908aa8b77665f348b4b03521901794f648b8ac34a581022cd6f2c97934d5c910cd91bc6593bbf2994687549037bc2520fcdc769b31484f29ffdd402acd0
+  languageName: node
+  linkType: hard
+
+"htmlparser2@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "htmlparser2@npm:8.0.2"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.0.1"
+    entities: "npm:^4.4.0"
+  checksum: 10c0/609cca85886d0bf2c9a5db8c6926a89f3764596877492e2caa7a25a789af4065bc6ee2cdc81807fe6b1d03a87bf8a373b5a754528a4cc05146b713c20575aab4
   languageName: node
   linkType: hard
 
@@ -11395,6 +11451,13 @@ __metadata:
   dependencies:
     readable-stream: "npm:^2.0.5"
   checksum: 10c0/ea4e509a5226ecfcc303ba6782cc269be8867d372b9bcbd625c88955df1987ea1a20da4643bf9270336415a398d33531ebf0d5f0d393b9283dc7c98bfcbd7b69
+  languageName: node
+  linkType: hard
+
+"leac@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "leac@npm:0.6.0"
+  checksum: 10c0/5257781e10791ef8462eb1cbe5e48e3cda7692486f2a775265d6f5216cc088960c62f138163b8df0dcf2119d18673bfe7b050d6b41543d92a7b7ac90e4eb1e8b
   languageName: node
   linkType: hard
 
@@ -13719,6 +13782,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parseley@npm:^0.12.0":
+  version: 0.12.1
+  resolution: "parseley@npm:0.12.1"
+  dependencies:
+    leac: "npm:^0.6.0"
+    peberminta: "npm:^0.9.0"
+  checksum: 10c0/df3de74172b72305b867298a71e5882c413df75d30f2bafb5fb70779dfd349c5e4db03441fbf8ca83da8e4aa72bd0ef2b5c73086c4825d27d1c649d61bc0bcc0
+  languageName: node
+  linkType: hard
+
 "parseurl@npm:^1.3.3":
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
@@ -13827,6 +13900,13 @@ __metadata:
   version: 2.0.3
   resolution: "pathe@npm:2.0.3"
   checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
+"peberminta@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "peberminta@npm:0.9.0"
+  checksum: 10c0/59c2c39269d9f7f559cf44582f1c0503524c6a9bc3478e0309adba2b41c71ab98745a239a4e6f98f46105291256e6d8f12ae9860d9f016b1c9a6f52c0b63bfe7
   languageName: node
   linkType: hard
 
@@ -14061,6 +14141,7 @@ __metadata:
     react-transition-group: "npm:^4.4.1"
     react-window: "npm:^2.0.0"
     remark-gfm: "npm:^4.0.0"
+    resend: "npm:^4.0.0"
     source-map-explorer: "npm:^2.5.2"
     split-grid: "npm:^1.0.11"
     styled-components: "npm:^6.0.0"
@@ -14228,7 +14309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.0.0":
+"prettier@npm:^3.0.0, prettier@npm:^3.5.3":
   version: 3.9.6
   resolution: "prettier@npm:3.9.6"
   bin:
@@ -14666,6 +14747,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-promise-suspense@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "react-promise-suspense@npm:0.3.4"
+  dependencies:
+    fast-deep-equal: "npm:^2.0.1"
+  checksum: 10c0/ab7a22f5400f9e9933995537bf6430a4c79e33a121aedb51864968e7604e5c40421fd539ead62554f32300b7d49755c79636de06caa36fe52973b626b4ddfebf
+  languageName: node
+  linkType: hard
+
 "react-router-dom@npm:^7.0.0":
   version: 7.18.2
   resolution: "react-router-dom@npm:7.18.2"
@@ -15029,6 +15119,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resend@npm:^4.0.0":
+  version: 4.8.0
+  resolution: "resend@npm:4.8.0"
+  dependencies:
+    "@react-email/render": "npm:1.1.2"
+  checksum: 10c0/8836b529abe3188592c2df120f18c40b6378707cec86bcd28000e912b51dc9304080d8876fa4e4a52d328aa0390a5ca5362de53331e9317bce9bd29bff6c2b41
+  languageName: node
+  linkType: hard
+
 "resolve-from@npm:^4.0.0":
   version: 4.0.0
   resolution: "resolve-from@npm:4.0.0"
@@ -15382,6 +15481,15 @@ __metadata:
   version: 4.1.0
   resolution: "secure-json-parse@npm:4.1.0"
   checksum: 10c0/52b3f8125ea974db1333a5b63e6a1df550c36c0d5f9a263911d6732812bd02e938b30be324dcbbb9da3ef9bf5a84849e0dd911f56544003d3c09e8eee12504de
+  languageName: node
+  linkType: hard
+
+"selderee@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "selderee@npm:0.11.0"
+  dependencies:
+    parseley: "npm:^0.12.0"
+  checksum: 10c0/c2ad8313a0dbf3c0b74752a8d03cfbc0931ae77a36679cdb64733eb732c1762f95a5174249bf7e8b8103874cb0e013a030f9c8b72f5d41e62f1d847d4a845d39
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

`https://plantswap.finance/contact-us` returns 404 for every visitor except those whose connected wallet matches `MASTERGARDENERDEVADDRESS`. The route was only mounted inside the `MenuDev` branch of `App.tsx`, so regular users fell through to `<NotFound />`.

Even when reachable, the form used `@emailjs/browser` with hardcoded service / template / public keys committed in source, the email body still said "Sent from ESportsCentral.ca" — residue from a fork — and the page header read "Contact-Us / Learn how to connect your wallet to Plantswap" (wallet-connect copy left over from another screen).

The submit button was also `onClick={() => handleSubmit}` — a reference, not an invocation — so clicking it did nothing on top of all that.

## What this PR does

### Backend (Resend via Netlify function)

- Adds `functions/contact-us.js` — a Netlify function that delivers submissions via the Resend SDK. Reads `RESEND_API_KEY`, `CONTACT_TO_EMAIL`, `CONTACT_FROM_EMAIL` from `process.env` (server-side only — set in the Netlify dashboard; never committed). Validates input, silently accepts honeypot trips, returns 400 / 405 / 500 with appropriate messages.
- Adds `src/utils/calls/contact.ts` — thin fetch wrapper mirroring `src/utils/calls/visitors.ts`. Calls `/.netlify/functions/contact-us` (same convention as every other caller in the repo).
- Adds `resend@^4.0.0` to `dependencies`.
- Documents the three server-side env vars in `.env.example` (with a comment that they are NOT added to `.env.development` / `.env.production` because Vite only inlines `REACT_APP_*` vars into the client bundle).

### Frontend

- **Mounts `<Route path="/contact-us" element={<ContactUs />} />` in the regular `<Menu>` branch** of `App.tsx` (alongside `/documentation`), keeping the existing one in `MenuDev`. **Fixes the 404.**
- Changes the `Contact` menu entry to a relative `href: '/contact-us'` (drops the absolute `https://plantswap.finance/contact-us` URL and `_blank` target), and adds a matching entry in `MenuDev/config.ts` for symmetry.
- Rewrites `ContactUs.tsx`:
  - **New hero** — "Get in touch" heading, an intro paragraph about what PlantSwap does, plus the help.svg illustration instead of the off-topic roadmap.svg.
  - **"What can we help you with?" section** — four reason cards (HelpIcon, TeamPlayerIcon, MegaphoneIcon, VerifiedIcon) explaining when to use the form: wallet & swap support, partnerships & listings, press & media, security disclosures. Each card includes a sentence or two of context so visitors can pick the right reason.
  - **Keeps the existing Resend-backed form** — drops `@emailjs/browser` and the hidden `emailSubject`/`emailBody` inputs (server composes the email now); adds a hidden honeypot input (off-screen, `tabIndex={-1}`, `aria-hidden`); fixes the broken submit button (removed the `onClick={() => handleSubmit}` no-op); adds inline error and sending states; disables inputs and changes button label while sending.
  - **"Other ways to reach us"** — inline links to GitHub, Blog, and the in-app Roadmap.
  - **Response time note** — explains we typically reply within 2–3 business days and to prefix security issues with "Security" in the subject.

## Out of scope (follow-up)

- `src/views/Dashboard/UsernamesList.tsx` and `UsersList.tsx` still use `@emailjs/browser` with hardcoded keys — separate cleanup PR.
- `src/views/ContactUs/helper.tsx` has hardcoded French strings — separate i18n pass.
- Form labels (`t('Your name')`, `t('Subjet')`, etc.) aren't in `translations.json`; this is pre-existing behaviour and not changed here.

## Required Netlify env vars

Set these in the Netlify dashboard (Site settings → Environment variables) before deploying — they are intentionally not committed:

- `RESEND_API_KEY` — API key from <https://resend.com/api-keys>
- `CONTACT_TO_EMAIL` — destination inbox (defaults to `plantswapfinance@gmail.com` if unset)
- `CONTACT_FROM_EMAIL` — verified sender (defaults to `onboarding@resend.dev` for testing; override to a `contact@plantswap.finance` address once the domain's SPF + DKIM records are in Resend)

## Verification

- `yarn install` — picks up the new `resend` dep.
- `npx tsc --noEmit -p tsconfig.json` — no new TypeScript errors from these changes (the existing pre-existing errors in `ContactUs.tsx`, `MenuDev/*`, and the test files are unchanged on this branch vs `origin/master`).
- Local: `netlify dev`, navigate to `/contact-us`, submit, confirm a 200 response and an email lands in `CONTACT_TO_EMAIL`.
- Negative tests against `/.netlify/functions/contact-us`:
  - `curl -X POST -d '{}'` → 400
  - `curl -X POST -d '{"honeypot":"x","clientName":"a","email":"a@b.c","sujet":"s","message":"m"}'` → 200, no email sent
  - `curl` (no `-X POST`) → 405
  - With `RESEND_API_KEY` unset → 500 `{ "error": "Email service not configured" }`